### PR TITLE
German practice pipeline: transcript robustness + writing session UX

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -458,6 +458,67 @@ python tools/export_pdf.py --test             # verify tool is working
 
 ---
 
+## German Domain
+
+### Get a session
+
+```bash
+# Via Telegram (primary path)
+# Send to @minimoi_cmd_bot:  !german session
+
+# Or locally (dry-run to verify output without sending):
+cd ~/Projects/personal-ai-agents && source venv/bin/activate
+python _NewDomains/language-german/get_german_session.py \
+  --base-dir _NewDomains/language-german/language/german/ --dry-run
+```
+
+### Start / stop the Dropbox watcher
+
+```bash
+# Via Telegram:  !german watcher start  /  !german watcher stop
+
+# Or locally:
+cd ~/Projects/personal-ai-agents/_NewDomains/language-german
+source ../../venv/bin/activate
+python watch_transcripts.py &         # start in background
+pkill -f watch_transcripts.py         # stop
+```
+
+### Run the acceptance test suite
+
+```bash
+cd ~/Projects/personal-ai-agents/_NewDomains/language-german
+source ../../venv/bin/activate
+python run_tests.py                   # all 9 tests
+python run_tests.py --test 9          # single test
+```
+
+### Check pipeline status
+
+```bash
+# Via Telegram (recommended):  !german status
+
+# Or locally:
+cd ~/Projects/personal-ai-agents && source venv/bin/activate
+python _NewDomains/language-german/status.py \
+  --base-dir _NewDomains/language-german/language/german/
+```
+
+### Key file locations
+
+| Path | Purpose |
+|---|---|
+| `_NewDomains/language-german/ORCHESTRATOR.md` | Command routing reference for any orchestrating agent |
+| `_NewDomains/language-german/GERMAN_USER_GUIDE.md` | End-to-end practice workflow guide |
+| `_NewDomains/language-german/language/german/config/sync_config.json` | Dropbox paths, watcher settings, `agent_mode` |
+| `_NewDomains/language-german/language/german/config/prompts/` | Persona `.txt` files (one per persona) |
+| `_NewDomains/language-german/language/german/lessons/` | Daily lesson plan JSONs (gitignored) |
+| `_NewDomains/language-german/run_tests.py` | 9-test acceptance suite |
+| `~/Dropbox/German_Sessions/prompts/` | Generated session prompt files |
+| `~/Dropbox/German_Sessions/transcripts/inbox/` | Drop transcripts here after practice |
+
+---
+
 ## Documentation
 
 - `README.md` — Project overview and setup

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -446,6 +446,14 @@ cd ~/Projects/personal-ai-agents && source venv/bin/activate && python3 setup_ke
 # X OAUTH STATUS
 cd ~/Projects/personal-ai-agents && source venv/bin/activate
 python x_oauth2_authorize.py --status
+
+# EXPORT DOCS TO PDF (saved to ~/Downloads/)
+cd ~/Projects/personal-ai-agents && source venv/bin/activate
+python tools/export_pdf.py --bundle curator   # README, ARCHITECTURE, OPERATIONS, ROADMAP, VISION
+python tools/export_pdf.py --bundle german    # GERMAN_USER_GUIDE, GERMAN_SPEC
+python tools/export_pdf.py README.md          # single file
+python tools/export_pdf.py --list-bundles     # see all bundles
+python tools/export_pdf.py --test             # verify tool is working
 ```
 
 ---
@@ -457,6 +465,7 @@ python x_oauth2_authorize.py --status
 - `ROADMAP.md` — Build priorities and future work
 - `CHANGELOG.md` — Version history
 - `CREDENTIALS_SETUP.md` — Initial credential setup guide
+- `tools/export_pdf.py` — Export any markdown doc to PDF (`--bundle curator`, `--bundle german`, or single file; `--test` to verify)
 - This file (`OPERATIONS.md`) — Day-to-day operations
 
 **Repository:** https://github.com/robertvanstedum/personal-ai-agents

--- a/WAYS_OF_WORKING.md
+++ b/WAYS_OF_WORKING.md
@@ -321,3 +321,16 @@ decisions — patterns chosen, tradeoffs accepted, intentional behavior that sho
 be "fixed." Log a decision when the rationale would not be obvious from reading the
 code alone. What goes where table updated. First entry: DEC-001, filesystem
 reconciliation for deep dive URL resolution.
+
+**2026-04-24:** Testing rule added after regression. The writing-mode commit
+(c2b320e) changed `parse_transcript.py`, `reviewer.py`, and `status.py`, but
+acceptance tests only covered the new `Mode:` field. Voice mode pipeline output
+broke in production — raw JSON reached Telegram instead of the formatted summary —
+because Tests 1–5 didn't exercise the full end-to-end Telegram path. Fixed in
+commit d6102c3 (stderr redirect + output guard + Test 6).
+
+**Rule: When any feature in the German domain pipeline changes, run all acceptance
+tests (Tests 1–6), not just the tests for the feature that changed.** A change to
+parse_transcript.py can break reviewer.py output; a change to reviewer.py can break
+the Telegram summary. Tests are end-to-end for a reason — run the full suite every
+time.

--- a/_NewDomains/language-german/GERMAN_USER_GUIDE.md
+++ b/_NewDomains/language-german/GERMAN_USER_GUIDE.md
@@ -1,7 +1,7 @@
 # German Practice — User Guide
-**Version:** 1.2  
-**Date:** 2026-04-25  
-**Author:** Robert van Stedum  
+**Version:** 1.3
+**Date:** 2026-04-26
+**Author:** Robert van Stedum
 **Status:** Living document — update as workflow evolves
 
 > This guide describes the daily German practice workflow end to end. It is the reference for Robert, OpenClaw, and any agent working on the language-german domain. When the workflow changes, update this document first.
@@ -12,76 +12,62 @@
 
 Daily German practice has three phases:
 
-1. **Get today's session** — ask OpenClaw, receive a combined prompt package
-2. **Practice** — paste into Grok on iPhone, have the conversation
-3. **Process** — paste transcript to pipeline bot, receive review and Anki cards
+1. **Get today's session** — send `!german session` to `@minimoi_cmd_bot`, receive prompt in Telegram and Dropbox
+2. **Practice** — open prompt in Grok on iPhone, have the conversation
+3. **Process** — drop transcript in Dropbox inbox (or paste to bot), receive review and Anki cards
 
 Everything else is optional or automated. These three steps are the daily minimum.
+
+> **Direct mode is now the default.** As of 2026-04-26, `telegram_bot.py` handles all `!german` commands directly. OpenClaw is not in the loop for session commands. Command routing logic lives in `_NewDomains/language-german/ORCHESTRATOR.md`.
 
 ---
 
 ## Phase 1 — Get Today's Session
 
-### On any device (laptop or iPhone via Telegram)
-
-Send to `minimoi_agent_bot`:
+### Send to `@minimoi_cmd_bot`
 
 ```
-Pull today's German session
+!german session
 ```
 
-Or any natural variation:
-- "What's my German session today?"
-- "Give me today's German prompt"
-- "German session please"
+The bot calls `get_german_session.py` directly, sends the full prompt to Telegram, and writes a `.txt` file to `~/Dropbox/German_Sessions/prompts/`. No OpenClaw involved.
 
-### What OpenClaw sends back
-
-A single combined message in this format:
+### What the prompt looks like
 
 ```
 📚 Today's German Session — Lesson N
 Persona: [Name] — [Role]
 Scenario: [scenario_label]
-Carry forward: [error or vocabulary from last session]
+Carry forward: [corrected phrase from last session]
+Warm-up: [warm-up instruction]
+Prompt: [speaking task for this session]
 
-─── PASTE THIS INTO GROK ───
+=== SESSION INSTRUCTIONS — READ BEFORE STARTING ===
+[universal behavioral rules for the AI — do not edit]
 
-[full persona prompt — copy everything in this section]
+=== CHARACTER AND SCENARIO BELOW ===
+[full persona prompt]
 
-─── HOW TO END THE SESSION ───
-
-When finished, say to Grok:
-"End session. Give me a clean transcript in this format:
-
----SESSION---
-Date: YYYY-MM-DD
-Persona: [Persona Name]
-Scenario: [scenario_label]
-Duration: [number only, e.g. 12]
-
-[Persona Name]: [turn text]
-Robert: [turn text]
-[continue alternating turns...]
----END---"
-
-Then copy everything between ---SESSION--- and ---END---
-and paste to minimoi_cmd_bot.
+=== HOW TO END THIS SESSION ===
+[transcript format instructions]
 ```
 
-### How OpenClaw finds this information
+The universal header (SESSION INSTRUCTIONS block) locks down model behavior — gender, scenario medium, no name prefix, language, correction style, start trigger. It works with any AI model (Grok, Claude, ChatGPT).
 
-- Today's lesson plan: `_NewDomains/language-german/language/german/lessons/` — most recent file
-- Persona prompt: `_NewDomains/language-german/language/german/config/prompts/[persona_name].txt`
-- If no lesson plan exists yet: use `domain.json → active_persona` and `bakery_order` as default scenario
+### How the pipeline finds this information
+
+- Today's lesson plan: `language/german/lessons/YYYY-MM-DD_lesson.json` — most recent file
+- Persona prompt: `language/german/config/prompts/[persona_name].txt`
+- If no lesson exists: falls back to `domain.json → active_persona` and `bakery_order`
 
 ---
 
 ## Phase 2 — Practice on iPhone
 
-1. Open Grok iOS → start a new chat
-2. Paste the full prompt from the `─── PASTE THIS INTO GROK ───` section
-3. Say: **"Start today's session"**
+1. Open Grok iOS → **start a new chat** (always a fresh chat — no carry-over context)
+2. Open the prompt file from `~/Dropbox/German_Sessions/prompts/` — or use the Telegram message
+3. Paste the full prompt into Grok
+4. Say: **"Start today's session"**
 4. Practice for 10–15 minutes — speak naturally, make mistakes, recover
 5. When finished, say the end phrase exactly:
 
@@ -104,9 +90,10 @@ Robert: [turn text]
 7. Copy everything from `---SESSION---` to `---END---` inclusive
 
 **Tips:**
-- Replace YYYY-MM-DD with today's date before saying the end phrase, or let Grok fill it in
+- Always start a new Grok chat — carrying context from a previous session causes wrong scenario or persona bleed
+- If Grok starts in the wrong scenario (in-person instead of phone call), say: "Stop. Reset. Start today's session." — the universal header takes effect on a fresh read
 - Duration is your rough estimate — 8, 10, 12 minutes — doesn't need to be exact
-- If Grok doesn't format it correctly, say: "Please reformat using exactly the template I gave you"
+- Grok may write the transcript header all on one line (e.g. `Date: 2026-04-26 Persona: Klaus ...`) — the pipeline handles this format correctly
 
 ---
 
@@ -145,27 +132,26 @@ Tap a rating — this is your feedback signal. It takes one second and matters f
 
 ## Writing Sessions
 
-Writing sessions use the same personas, scenarios, and pipeline as voice sessions. Use them when Grok voice is unavailable, or to build a voice vs writing error comparison over time. The pipeline handles `Mode: writing` automatically — no other changes needed.
+Writing sessions use the same personas, scenarios, and pipeline as voice sessions. Use them when Grok voice is unavailable, or to build a voice vs writing error comparison over time.
 
-### Option A — Request via OpenClaw (when command is live)
-
-Send to `minimoi_agent_bot`:
+### Request via `@minimoi_cmd_bot`
 
 ```
-writing café Maria
-writing hotel Herr Fischer
-writing bakery Frau Berger
+!german writing
 ```
 
-OpenClaw generates a writing-mode prompt file marked with `⌨️ WRITING SESSION` at the top and pre-fills `Mode: writing` in the transcript template. Everything else is the same as a normal session.
+The bot generates a writing-mode prompt — identical to `!german session` but with:
+- `⌨️ WRITING SESSION` header at the very top of the message
+- `Mode: writing` pre-filled in the transcript footer template
 
-### Option B — Run manually today (before OpenClaw command is live)
+### How to run a writing session
 
-1. Open **Claude.ai** or **Grok** in text mode (browser or app)
-2. Paste the persona prompt from `config/prompts/[persona].txt`
-3. Say: **"Start today's writing session"**
-4. Type your turns — no voice required. The persona will gently correct mistakes in-character.
-5. When finished, say:
+1. Send `!german writing` to `@minimoi_cmd_bot` → prompt arrives in Telegram and Dropbox
+2. Open **Claude.ai** or **Grok** in text mode (browser or app) → **new chat**
+3. Paste the full prompt
+4. Say: **"Start today's session"**
+5. Type your turns — no voice required. The persona corrects mistakes in-character.
+6. When finished, say:
 
 ```
 End session. Give me a clean transcript in this format:
@@ -183,8 +169,8 @@ Robert: [turn text]
 ---END---
 ```
 
-6. Copy the full block from `---SESSION---` to `---END---` inclusive
-7. **Before submitting:** confirm `Mode: writing` is in the header
+7. Copy the full block from `---SESSION---` to `---END---` inclusive
+8. **Before submitting:** confirm `Mode: writing` is in the header — the prompt pre-fills it, but verify Grok kept it
 
 **Tip:** Turn off auto-correct before you start — the pipeline tracks your actual mistakes.
 
@@ -233,18 +219,21 @@ Cards include example sentences and tags for filtering by topic (food, hotel, di
 
 ---
 
-## `!german` Commands (send to `minimoi_cmd_bot`)
+## `!german` Commands (send to `@minimoi_cmd_bot`)
+
+All commands are handled directly by `telegram_bot.py` in direct mode — no OpenClaw needed.
 
 | Command | What it does |
 |---|---|
 | `!german session` | Generate today's session → send to Telegram + write to Dropbox |
-| `!german drill [persona] [scenario] [N]` | Generate N drill prompts → all written to Dropbox, first sent to Telegram |
-| `!german status` | Today's session summary + next lesson |
-| `!german progress` | Cumulative stats — sessions, minutes, cards, top errors |
-| `!german today` | Re-run reviewer on today's most recent session |
-| `!german persona [name]` | Override tomorrow's persona |
+| `!german writing` | Generate writing-mode session → `⌨️` header at top, `Mode: writing` in footer |
+| `!german drill [N]` | Generate N drill prompts → all written to Dropbox, first sent to Telegram |
+| `!german status` | Current progress summary — sessions, minutes, Anki cards, next lesson |
 | `!german anki` | Path to today's Anki CSV |
-| `!german debug` | Dump last inbox file + last session header |
+| `!german watcher start` | Start the Dropbox transcript watcher in background |
+| `!german watcher stop` | Stop the watcher |
+
+Command routing logic is documented in `_NewDomains/language-german/ORCHESTRATOR.md`.
 
 ---
 
@@ -282,10 +271,14 @@ That's it. Everything else — Anki review, HTML page, writing exercise — is o
 
 | Feature | Status | When |
 |---|---|---|
-| Auto-trigger (no delimiter needed) | ✅ Freeform fallback shipped | Done |
+| Auto-trigger (no delimiter needed) | ✅ Shipped | Done |
 | Dropbox bridge + watcher | ✅ Shipped 2026-04-25 | Done |
 | Drill mode | ✅ Shipped 2026-04-25 | Done |
 | Anki auto-import via AnkiConnect | ✅ Shipped 2026-04-25 | Done |
+| Direct mode (`!german session` no OpenClaw) | ✅ Shipped 2026-04-26 | Done |
+| Universal session header (any AI model) | ✅ Shipped 2026-04-26 | Done |
+| Writing mode via `!german writing` | ✅ Shipped 2026-04-26 | Done |
+| 9-test acceptance suite | ✅ Shipped 2026-04-26 | Done |
 | Session quality rating buttons | Planned | Next |
 | HTML session review page | Planned | Next |
 | Morning German reminder | Planned | Next |
@@ -439,6 +432,7 @@ _NewDomains/language-german/
 
 | Version | Date | Changes |
 |---|---|---|
-| 1.2 | 2026-04-25 | Add Dropbox iPhone workflow, Rapid-Drill mode, Anki auto-import sections; update commands table + What's Not Built Yet |
-| 1.1 | 2026-04-24 | Add Writing Sessions section — OpenClaw command, manual workflow, iPhone steps, pipeline note |
-| 1.0 | 2026-04-21 | Initial guide — covers current manual workflow and target automated workflow |
+| 1.3 | 2026-04-26 | Direct mode default — `!german session` via `@minimoi_cmd_bot`; add `!german writing`, `!german watcher start/stop`; remove stale commands; universal header; Grok inline-header note; ORCHESTRATOR.md mention |
+| 1.2 | 2026-04-25 | Add Dropbox iPhone workflow, Rapid-Drill mode, Anki auto-import sections; update commands table |
+| 1.1 | 2026-04-24 | Add Writing Sessions section |
+| 1.0 | 2026-04-21 | Initial guide |

--- a/_NewDomains/language-german/GERMAN_USER_GUIDE.md
+++ b/_NewDomains/language-german/GERMAN_USER_GUIDE.md
@@ -1,6 +1,6 @@
 # German Practice — User Guide
-**Version:** 1.1  
-**Date:** 2026-04-24  
+**Version:** 1.2  
+**Date:** 2026-04-25  
 **Author:** Robert van Stedum  
 **Status:** Living document — update as workflow evolves
 
@@ -237,6 +237,8 @@ Cards include example sentences and tags for filtering by topic (food, hotel, di
 
 | Command | What it does |
 |---|---|
+| `!german session` | Generate today's session → send to Telegram + write to Dropbox |
+| `!german drill [persona] [scenario] [N]` | Generate N drill prompts → all written to Dropbox, first sent to Telegram |
 | `!german status` | Today's session summary + next lesson |
 | `!german progress` | Cumulative stats — sessions, minutes, cards, top errors |
 | `!german today` | Re-run reviewer on today's most recent session |
@@ -281,11 +283,103 @@ That's it. Everything else — Anki review, HTML page, writing exercise — is o
 | Feature | Status | When |
 |---|---|---|
 | Auto-trigger (no delimiter needed) | ✅ Freeform fallback shipped | Done |
-| `!german start` persona menu | Step 2 in build plan | This week |
-| Session quality rating buttons | Step 3 in build plan | This week |
-| HTML session review page | Step 4 in build plan | This week |
-| iCloud prompt file drop | Step 5 in build plan | This week |
-| Morning German reminder | Planned | This week |
+| Dropbox bridge + watcher | ✅ Shipped 2026-04-25 | Done |
+| Drill mode | ✅ Shipped 2026-04-25 | Done |
+| Anki auto-import via AnkiConnect | ✅ Shipped 2026-04-25 | Done |
+| Session quality rating buttons | Planned | Next |
+| HTML session review page | Planned | Next |
+| Morning German reminder | Planned | Next |
+
+---
+
+## Dropbox iPhone Workflow
+
+The Dropbox bridge lets you go from Telegram command to Grok practice without copy-pasting between apps. The watcher on your Mac fires the pipeline within 15 seconds of a transcript landing in the inbox.
+
+### Before practice
+
+1. In Telegram (either bot), send: `!german session` or `"Pull today's German session"`
+2. Pipeline generates today's prompt → sends to Telegram AND writes a `.txt` file to `~/Dropbox/German_Sessions/prompts/`
+3. On your iPhone, open the Dropbox app → navigate to `German_Sessions/prompts/`
+4. Open today's file → if Grok accepts `.txt` attachments, attach it directly; otherwise copy the text
+5. In Grok: paste (or attach) → say **"Start today's session"** → practice
+
+### After practice
+
+1. Say to Grok: **"End session. Give me a clean transcript."**
+2. Copy the full block from `---SESSION---` to `---END---` (inclusive)
+3. In the Dropbox app: navigate to `German_Sessions/transcripts/inbox/` → create a new `.txt` file → paste → save
+4. Done — the watcher detects the file within 15 seconds and fires the full pipeline
+
+### What the watcher does automatically
+
+1. Parses the transcript → creates session JSON
+2. Runs `reviewer.py` → error analysis + Anki cards
+3. Imports cards into Anki (if AnkiConnect is open on your Mac)
+4. Generates the next session prompt → writes to Dropbox + sends to Telegram
+5. Moves the transcript to `transcripts/processed/`
+
+**Fallback:** If the Dropbox inbox doesn't work, paste the transcript directly to `minimoi_cmd_bot` as before — the manual path is always available.
+
+---
+
+## Rapid-Drill Mode
+
+Use drill mode to repeat a scenario multiple times in quick succession — useful for cementing a specific skill (e.g. U-Bahn directions, ordering coffee) before Vienna.
+
+### How to trigger
+
+In Telegram:
+```
+!german drill Stefan ubahn 3
+!german drill Maria café 5
+!german drill Frau Novak pharmacy 2
+```
+
+Or natural language:
+- "Start German session in drill mode"
+- "Drill café Maria 3 times"
+- "3 drill sessions"
+
+### What happens
+
+1. Pipeline generates N prompt files → all written to Dropbox (`prompts/..._drill1.txt` through `..._drillN.txt`)
+2. The first session prompt is sent to Telegram immediately
+3. Each drill file includes a `Drill-Session: K of N` line in the end-session transcript template — **you don't need to type this manually**
+
+### Working through drills
+
+- Open each drill file from Dropbox in order, practice, drop transcript in inbox
+- After each non-final session: Anki cards are generated, but the lesson plan does **not** rotate — you stay on the same persona/scenario
+- After the final session (`K == N`): full pipeline runs, lesson rotates to the next one
+
+**Why drills don't advance the lesson:** Each mid-drill session generates Anki cards from your errors. The lesson rotation waits until you've done all N repetitions, so you're reinforcing the same material without disrupting the lesson sequence.
+
+---
+
+## Anki Auto-Import
+
+After each session, a CSV file is written to `language/german/anki/YYYY-MM-DD_anki.csv`.
+
+### Automatic import (when Anki is open)
+
+The watcher calls `import_cards.py` automatically. If Anki desktop is open and AnkiConnect is running, cards are imported immediately. If not, the pipeline continues and logs a warning — nothing breaks.
+
+**To enable AnkiConnect:** Install the AnkiConnect add-on in Anki (add-on code: `2055492159`). Leave Anki open on your Mac before dropping a transcript in the inbox.
+
+### Manual import
+
+1. Open Anki → File → Import
+2. Navigate to `_NewDomains/language-german/language/german/anki/`
+3. Select the most recent CSV → map fields: Front, Back, Tags → Import
+
+### What the cards contain
+
+- Front: German word or phrase (or fill-in-the-blank sentence)
+- Back: English translation + example sentence
+- Tags: session date, persona, error type (e.g. `word_order`, `gender`, `vocab`)
+
+Use Anki's tag browser to filter by error type and drill your weakest areas.
 
 ---
 
@@ -318,14 +412,25 @@ _NewDomains/language-german/
       domain.json          ← active persona, lesson counter, reviewer model
       personas.json        ← all 8 personas with speaking prompts
       prompts/             ← one .txt file per persona (paste into Grok)
+      sync_config.json     ← Dropbox paths + watcher settings
     sessions/              ← session JSONs (gitignored)
-      inbox/               ← raw transcripts drop here first
     anki/                  ← daily Anki CSVs (gitignored)
     lessons/               ← daily lesson plans (gitignored)
     progress.json          ← cumulative stats (gitignored)
   parse_transcript.py
   reviewer.py
+  watch_transcripts.py     ← Dropbox inbox watcher (run at startup)
+  get_german_session.py    ← session package generator
+  import_cards.py          ← Anki auto-import via AnkiConnect
   status.py
+
+~/Dropbox/German_Sessions/
+  prompts/                 ← generated session prompt files (.txt)
+  transcripts/
+    inbox/                 ← drop your transcript here after practice
+    processed/             ← watcher moves files here after pipeline runs
+  logs/
+    watcher.log            ← watcher activity log (rotates at 1MB)
 ```
 
 ---
@@ -334,5 +439,6 @@ _NewDomains/language-german/
 
 | Version | Date | Changes |
 |---|---|---|
+| 1.2 | 2026-04-25 | Add Dropbox iPhone workflow, Rapid-Drill mode, Anki auto-import sections; update commands table + What's Not Built Yet |
 | 1.1 | 2026-04-24 | Add Writing Sessions section — OpenClaw command, manual workflow, iPhone steps, pipeline note |
 | 1.0 | 2026-04-21 | Initial guide — covers current manual workflow and target automated workflow |

--- a/_NewDomains/language-german/ORCHESTRATOR.md
+++ b/_NewDomains/language-german/ORCHESTRATOR.md
@@ -1,0 +1,109 @@
+# German Domain Orchestrator Instructions
+**Version:** 1.0
+**Read this file before handling any German domain command.**
+**These instructions are binding and override agent memory.**
+
+---
+
+## Path Variables
+
+MINI_MOI_ROOT = ~/Projects/personal-ai-agents
+GERMAN_ROOT   = _NewDomains/language-german/
+GERMAN_BASE   = _NewDomains/language-german/language/german/
+ANKI_IMPORT   = _NewDomains/language-german/language/german/utilities/anki_import/
+
+---
+
+## Command Routing
+
+For every German domain command:
+1. Read the command mapping below
+2. Run the exact shell command using your shell tool
+3. Forward stdout verbatim — do not paraphrase, summarize, or modify
+4. If the command fails: forward stderr verbatim with a ⚠️ prefix
+5. Never generate content yourself
+
+---
+
+## Commands
+
+### Session Pull
+Triggers: !german session, pull today's German session, German session
+please, What's my German session today?, give me today's prompt,
+next German session
+
+Shell command:
+```
+cd $MINI_MOI_ROOT && source venv/bin/activate && \
+python $GERMAN_ROOT/get_german_session.py \
+  --base-dir $GERMAN_BASE --dropbox --send
+```
+
+### Writing Session
+Triggers: !german writing, writing session, next writing session,
+writing [scenario] [persona]
+
+Shell command: same as session pull
+Append to output: "⌨️ WRITING SESSION — Add Mode: writing to transcript header."
+
+### Drill Mode
+Triggers: !german drill [N], drill [N], drill [scenario] [persona] [N]
+
+Shell command:
+```
+cd $MINI_MOI_ROOT && source venv/bin/activate && \
+python $GERMAN_ROOT/get_german_session.py \
+  --base-dir $GERMAN_BASE --dropbox --send --drill [N]
+```
+
+### Status
+Triggers: !german status, German status, how am I doing
+
+Shell command:
+```
+cd $MINI_MOI_ROOT && source venv/bin/activate && \
+python $GERMAN_ROOT/status.py --base-dir $GERMAN_BASE
+```
+
+### Anki Import
+Triggers: !german anki, import anki cards, upload anki
+
+Shell command:
+```
+cd $MINI_MOI_ROOT && source venv/bin/activate && \
+python $GERMAN_ROOT/import_cards.py
+```
+
+### Watcher Start
+Triggers: !german watcher start, start the watcher
+
+Shell command:
+```
+cd $MINI_MOI_ROOT/$GERMAN_ROOT && \
+$MINI_MOI_ROOT/venv/bin/python3 watch_transcripts.py &
+```
+
+### Watcher Stop
+Triggers: !german watcher stop, stop the watcher
+
+Shell command:
+```
+pkill -f watch_transcripts.py
+```
+
+---
+
+## Rules
+
+1. Never generate session content yourself — the scripts do it
+2. Never summarize or paraphrase stdout — forward verbatim
+3. Never route !german session to @minimoi_cmd_bot — wrong bot
+4. Always read current lesson from files — never from memory
+5. Never hardcode absolute paths — use the path variables above
+
+---
+
+## Machine Migration
+
+Update the four path variables at the top when changing machines.
+All commands follow automatically.

--- a/_NewDomains/language-german/README.md
+++ b/_NewDomains/language-german/README.md
@@ -1,0 +1,138 @@
+# language-german
+
+German language practice pipeline. Runs as a domain inside the personal-ai-agents repo.
+
+**Status:** Operational as of 2026-04-26. 27 sessions completed in 7 days. 8 Vienna personas. Voice and writing modes tracked separately.
+
+---
+
+## What it does
+
+1. Generates a daily session prompt (persona + scenario + universal AI behavioral rules)
+2. Delivers the prompt to Telegram and Dropbox
+3. Watches the Dropbox inbox for transcripts dropped from iPhone
+4. Parses transcripts → error review → Anki cards → next lesson plan
+
+Everything after step 2 is automatic once the watcher is running.
+
+---
+
+## Daily workflow (3 steps)
+
+```
+1. @minimoi_cmd_bot ← !german session      [prompt arrives in Telegram + Dropbox]
+2. Grok iOS         ← paste prompt, practice, drop transcript in Dropbox inbox
+3. Pipeline fires automatically within 15 seconds
+```
+
+---
+
+## Commands (`@minimoi_cmd_bot`)
+
+| Command | Effect |
+|---|---|
+| `!german session` | Generate today's session prompt |
+| `!german writing` | Generate writing-mode prompt (`Mode: writing` in footer) |
+| `!german drill [N]` | Generate N drill prompts, first sent to Telegram |
+| `!german status` | Progress summary — sessions, minutes, Anki cards, next lesson |
+| `!german anki` | Path to today's Anki CSV |
+| `!german watcher start` | Start Dropbox transcript watcher |
+| `!german watcher stop` | Stop watcher |
+
+**Direct mode:** `telegram_bot.py` handles all commands directly. OpenClaw is not needed for session commands. See `ORCHESTRATOR.md` for routing logic.
+
+---
+
+## Key files
+
+```
+_NewDomains/language-german/
+  ORCHESTRATOR.md              ← agent-agnostic command routing reference
+  GERMAN_USER_GUIDE.md         ← full workflow guide for daily use
+  run_tests.py                 ← 9-test acceptance suite
+  get_german_session.py        ← session package generator (--dropbox --send --writing --drill N)
+  watch_transcripts.py         ← Dropbox inbox watcher (poll every 15s)
+  parse_transcript.py          ← transcript parser (multi-line, em-dash, and Grok inline format)
+  reviewer.py                  ← session reviewer + lesson rotation + Anki generation
+  status.py                    ← progress summary
+  import_cards.py              ← Anki auto-import via AnkiConnect
+  test_fixtures/               ← transcript fixtures for acceptance tests
+  language/german/
+    config/
+      domain.json              ← active persona, lesson counter
+      personas.json            ← 8 personas with scenarios and warm-up variants
+      prompts/                 ← one .txt file per persona (≤3500 chars)
+      sync_config.json         ← Dropbox paths, watcher settings, agent_mode
+    lessons/                   ← daily lesson plans (gitignored)
+    sessions/                  ← session JSONs (gitignored)
+    anki/                      ← daily Anki CSVs (gitignored)
+    progress.json              ← cumulative stats (gitignored)
+```
+
+---
+
+## The 8 Vienna personas
+
+| Persona | Role | Register |
+|---|---|---|
+| Frau Berger | Bakery owner | Informal Austrian |
+| Herr Fischer | Hotel receptionist | Formal Hochdeutsch |
+| Maria | Café waitress | Natural, Viennese pace |
+| Dr. Huber | Museum guide | Explanatory, follow-up questions |
+| Stefan | U-Bahn stranger | Normal speed, directions |
+| Frau Novak | Pharmacist | Precise, practical |
+| Klaus | Upscale waiter | Formal register, phone reservations |
+| Anna | Airbnb host | Friendly, apartment vocabulary |
+
+Persona files: `language/german/config/prompts/`. Authoring standard: ≤3500 chars, 6-8 vocab items, 3-4 sentence description. Standard comment required on line 1.
+
+---
+
+## Universal session header
+
+Every prompt includes a `=== SESSION INSTRUCTIONS ===` block before the persona text. This block instructs any AI model (Grok, Claude, ChatGPT) to:
+
+- Play the correct gender
+- Respect the scenario medium (phone call vs. in-person)
+- Not prefix each turn with their name
+- Respond in German only
+- Gently correct errors in-character
+- Wait for "Start today's session" before beginning
+
+---
+
+## Transcript format
+
+Grok produces transcripts in `---SESSION---` / `---END---` format. The parser handles:
+- Standard multi-line format
+- Em-dash format (`—SESSION—`) from iPhone autocorrect
+- Single-line format (`Date: 2026-04-26 Persona: Klaus Scenario: ...`) from Grok
+
+---
+
+## Running tests
+
+```bash
+cd _NewDomains/language-german && source ../../venv/bin/activate
+python run_tests.py        # 9/9 expected
+```
+
+Tests cover: transcript parsing (all 3 formats), session output (header, footer, carry-forward, writing mode), persona file standard, ORCHESTRATOR.md completeness.
+
+---
+
+## Configuration
+
+`language/german/config/sync_config.json`:
+
+```json
+{
+  "agent_mode": "direct",
+  "base_path": "~/Dropbox/German_Sessions",
+  "poll_interval_seconds": 15,
+  "max_prompt_chars": 4000
+}
+```
+
+`agent_mode: "direct"` — `telegram_bot.py` handles session commands itself.
+`agent_mode: "openclaw"` — session commands are routed to `@minimoi_agent_bot` instead.

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -210,11 +210,9 @@ UNIVERSAL_FOOTER = """\
 === HOW TO END THIS SESSION ===
 
 TO END THIS SESSION:
-1. Say: "End session."
-2. Switch to TEXT MODE (tap the keyboard icon)
-3. Type: "Give me the transcript"
-The transcript will be output as formatted text.
-DO NOT request the transcript while still in voice mode.
+1. Switch to TEXT MODE first (tap the keyboard icon)
+2. Type: "End session. Give me the transcript."
+Do NOT say "End session" while in voice mode.
 
 Output ONLY the following block —
 nothing before it, nothing after it, no commentary:

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -6,6 +6,7 @@ Usage:
   python get_german_session.py --base-dir language/german/
   python get_german_session.py --base-dir language/german/ --date 2026-04-25
   python get_german_session.py --base-dir language/german/ --dry-run
+  python get_german_session.py --base-dir language/german/ --send
 """
 import argparse
 import json
@@ -13,6 +14,32 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+try:
+    import keyring
+    import requests
+except ImportError:
+    keyring = None
+    requests = None
+
+
+def _send_telegram(text: str) -> None:
+    if keyring is None or requests is None:
+        print("⚠️  keyring/requests not available — cannot send to Telegram.", file=sys.stderr)
+        sys.exit(1)
+    token = keyring.get_password("telegram", "polling_bot_token")
+    chat_id = keyring.get_password("telegram", "chat_id")
+    if not token or not chat_id:
+        print("⚠️  Telegram credentials not found in Keychain (telegram/polling_bot_token, telegram/chat_id).", file=sys.stderr)
+        sys.exit(1)
+    resp = requests.post(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        json={"chat_id": chat_id, "text": text, "disable_web_page_preview": True},
+        timeout=30,
+    )
+    if not resp.ok:
+        print(f"⚠️  Telegram send failed: {resp.status_code} {resp.text[:200]}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _slug(name: str) -> str:
@@ -63,6 +90,7 @@ def main():
     parser.add_argument('--base-dir', default='language/german/', help='Path to language/german/ directory')
     parser.add_argument('--date', help='Override date (YYYY-MM-DD, for testing)')
     parser.add_argument('--dry-run', action='store_true', help='Print output without sending anywhere')
+    parser.add_argument('--send', action='store_true', help='Send session package to Telegram after printing')
     args = parser.parse_args()
 
     base = Path(args.base_dir)
@@ -150,7 +178,12 @@ def main():
         "Send transcript to @minimoi_cmd_bot to process.",
     ]
 
-    print('\n'.join(lines))
+    output = '\n'.join(lines)
+    print(output)
+
+    if args.send and not args.dry_run:
+        _send_telegram(output)
+        print("✅ Sent to Telegram.", file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -209,9 +209,14 @@ These rules override everything else. Follow them exactly.
 UNIVERSAL_FOOTER = """\
 === HOW TO END THIS SESSION ===
 
-When the session is over, say: "End session."
+TO END THIS SESSION:
+1. Say: "End session."
+2. Switch to TEXT MODE (tap the keyboard icon)
+3. Type: "Give me the transcript"
+The transcript will be output as formatted text.
+DO NOT request the transcript while still in voice mode.
 
-At that moment, switch to text and output ONLY the following block —
+Output ONLY the following block —
 nothing before it, nothing after it, no commentary:
 
 ---SESSION---

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -54,7 +54,7 @@ def _get_anthropic_client():
         raise RuntimeError(f"Cannot create Anthropic client: {e}")
 
 
-def _enforce_length(prompt: str, limit: int) -> str:
+def _enforce_length(prompt: str, limit: int, persona_name: str = "") -> str:
     if len(prompt) <= limit:
         return prompt
     original_len = len(prompt)
@@ -83,10 +83,25 @@ def _enforce_length(prompt: str, limit: int) -> str:
         )
         revised = response.content[0].text.strip()
         print(f"⚠️  Prompt revised by Haiku: {original_len} → {len(revised)} chars", file=sys.stderr)
+        if len(revised) > limit:
+            _hard_fail_length(persona_name, limit)
         return revised
+    except RuntimeError:
+        raise
     except Exception as e:
         print(f"⚠️  Haiku revision failed ({e}) — sending full prompt", file=sys.stderr)
         return prompt
+
+
+def _hard_fail_length(persona_name: str, limit: int) -> None:
+    slug = f"config/prompts/{_slug(persona_name)}.txt" if persona_name else "config/prompts/[persona].txt"
+    msg = f"⚠️ Session prompt too long after revision — trim {slug} and try again."
+    print(f"❌ Prompt still over limit after all passes — not sent", file=sys.stderr)
+    try:
+        _send_telegram(msg)
+    except Exception:
+        pass
+    sys.exit(1)
 
 
 def _load_sync_config() -> dict:
@@ -343,7 +358,7 @@ def main():
                 drill_session=k, drill_total=drill_total,
             )
             if not args.dry_run:
-                output = _enforce_length(output, max_chars)
+                output = _enforce_length(output, max_chars, persona_name)
             print(output)
             print()
 

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 """
-get_german_session.py — Assemble and print today's German practice session package.
+get_german_session.py — Assemble and deliver today's German practice session package.
 
 Usage:
   python get_german_session.py --base-dir language/german/
-  python get_german_session.py --base-dir language/german/ --date 2026-04-25
-  python get_german_session.py --base-dir language/german/ --dry-run
   python get_german_session.py --base-dir language/german/ --send
+  python get_german_session.py --base-dir language/german/ --dropbox --send
+  python get_german_session.py --base-dir language/german/ --drill 3 --dropbox --send
+  python get_german_session.py --base-dir language/german/ --drill 3 --drill-session 2 --dropbox
 """
 import argparse
 import json
+import random
 import re
 import sys
 from datetime import datetime, timezone
@@ -40,6 +42,23 @@ def _send_telegram(text: str) -> None:
     if not resp.ok:
         print(f"⚠️  Telegram send failed: {resp.status_code} {resp.text[:200]}", file=sys.stderr)
         sys.exit(1)
+
+
+def _load_sync_config() -> dict:
+    here = Path(__file__).parent
+    cfg_path = here / "language/german/config/sync_config.json"
+    if cfg_path.exists():
+        return json.loads(cfg_path.read_text(encoding="utf-8"))
+    return {}
+
+
+def _write_dropbox(sync_cfg: dict, filename: str, content: str) -> Path:
+    base = Path(sync_cfg.get("base_path", "~/Dropbox/German_Sessions")).expanduser()
+    prompts_dir = base / sync_cfg.get("prompts_dir", "prompts")
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    out = prompts_dir / filename
+    out.write_text(content, encoding="utf-8")
+    return out
 
 
 def _slug(name: str) -> str:
@@ -85,12 +104,78 @@ def _carry_forward(lesson: dict, progress: dict) -> str:
     return f"{top_error} ({count} total)"
 
 
+def _dropbox_filename(date_str: str, lesson_number: int, persona_name: str,
+                      scenario: str, drill_session: int = 0, drill_total: int = 0) -> str:
+    ts = datetime.now().strftime("%H%M")
+    slug_p = _slug(persona_name)
+    slug_s = scenario.replace(' ', '_').lower()
+    base = f"{date_str}_{ts}_lesson{lesson_number}_{slug_p}_{slug_s}"
+    if drill_total > 0:
+        return f"{base}_drill{drill_session}.txt"
+    return f"{base}.txt"
+
+
+def _build_package(date_str: str, persona_name: str, persona_role: str,
+                   lesson_number: int, scenario: str, warm_up: str,
+                   speaking_prompt: str, persona_prompt: str, carry: str,
+                   drill_session: int = 0, drill_total: int = 0) -> str:
+    drill_mode = drill_total > 0
+
+    lines = [
+        f"📚 Today's German Session — Lesson {lesson_number}",
+        f"Persona: {persona_name} — {persona_role}",
+        f"Scenario: {scenario}",
+        f"Carry forward: {carry}",
+    ]
+    if drill_mode:
+        lines.append(f"Drill: {drill_session} of {drill_total}")
+    if warm_up:
+        lines.append(f"Warm-up: {warm_up}")
+    if speaking_prompt:
+        lines.append(f"Prompt: {speaking_prompt}")
+
+    lines += [
+        "",
+        "─── PASTE INTO GROK OR CLAUDE ───",
+        "",
+        persona_prompt,
+        "",
+        "─── HOW TO END THE SESSION ───",
+        "",
+        'When finished say: "End session. Give me a clean transcript."',
+        "",
+        "Format:",
+        "---SESSION---",
+        f"Date: {date_str}",
+        f"Persona: {persona_name}",
+        f"Scenario: {scenario}",
+        "Duration: [number only, e.g. 12]",
+        "Mode: voice",
+    ]
+    if drill_mode:
+        lines.append("Drill: true")
+        lines.append(f"Drill-Session: {drill_session} of {drill_total}")
+    lines += [
+        "",
+        f"{persona_name}: [turn text]",
+        "Robert: [turn text]",
+        "[continue alternating turns...]",
+        "---END---",
+        "",
+        "Send transcript to @minimoi_cmd_bot to process.",
+    ]
+    return '\n'.join(lines)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Assemble today's German practice session package.")
     parser.add_argument('--base-dir', default='language/german/', help='Path to language/german/ directory')
     parser.add_argument('--date', help='Override date (YYYY-MM-DD, for testing)')
-    parser.add_argument('--dry-run', action='store_true', help='Print output without sending anywhere')
-    parser.add_argument('--send', action='store_true', help='Send session package to Telegram after printing')
+    parser.add_argument('--dry-run', action='store_true', help='Print output without writing or sending')
+    parser.add_argument('--send', action='store_true', help='Send session package to Telegram')
+    parser.add_argument('--dropbox', action='store_true', help='Write prompt file(s) to Dropbox prompts dir')
+    parser.add_argument('--drill', type=int, metavar='N', help='Generate N drill session prompts (one per session)')
+    parser.add_argument('--drill-session', type=int, metavar='K', help='Generate prompt for drill session K only (requires --drill N)')
     args = parser.parse_args()
 
     base = Path(args.base_dir)
@@ -130,7 +215,9 @@ def main():
         warm_up = lesson.get('warm_up', '')
         speaking_prompt = lesson.get('speaking_prompt', '')
 
-    persona_role = next((p['role'] for p in personas if p['name'] == persona_name), 'Unknown')
+    persona_obj = next((p for p in personas if p['name'] == persona_name), {})
+    persona_role = persona_obj.get('role', 'Unknown')
+    warm_up_variants = persona_obj.get('warm_up_variants', [])
 
     prompt_file = _find_prompt_file(prompts_dir, persona_name)
     if prompt_file is None:
@@ -141,49 +228,56 @@ def main():
     persona_prompt = prompt_file.read_text(encoding='utf-8').strip()
     carry = _carry_forward(lesson or {}, progress)
 
-    lines = [
-        f"📚 Today's German Session — Lesson {lesson_number}",
-        f"Persona: {persona_name} — {persona_role}",
-        f"Scenario: {scenario}",
-        f"Carry forward: {carry}",
-    ]
-    if warm_up:
-        lines.append(f"Warm-up: {warm_up}")
-    if speaking_prompt:
-        lines.append(f"Prompt: {speaking_prompt}")
+    sync_cfg = _load_sync_config() if args.dropbox else {}
 
-    lines += [
-        "",
-        "─── PASTE INTO GROK OR CLAUDE ───",
-        "",
-        persona_prompt,
-        "",
-        "─── HOW TO END THE SESSION ───",
-        "",
-        'When finished say: "End session. Give me a clean transcript."',
-        "",
-        "Format:",
-        "---SESSION---",
-        f"Date: {date_str}",
-        f"Persona: {persona_name}",
-        f"Scenario: {scenario}",
-        "Duration: [number only, e.g. 12]",
-        "Mode: voice",
-        "",
-        f"{persona_name}: [turn text]",
-        "Robert: [turn text]",
-        "[continue alternating turns...]",
-        "---END---",
-        "",
-        "Send transcript to @minimoi_cmd_bot to process.",
-    ]
+    drill_total = args.drill or 0
 
-    output = '\n'.join(lines)
-    print(output)
+    if drill_total > 0:
+        # Determine which session numbers to generate
+        if args.drill_session:
+            sessions_to_generate = [args.drill_session]
+        else:
+            sessions_to_generate = list(range(1, drill_total + 1))
 
-    if args.send and not args.dry_run:
-        _send_telegram(output)
-        print("✅ Sent to Telegram.", file=sys.stderr)
+        first_output = None
+        for k in sessions_to_generate:
+            wu = random.choice(warm_up_variants) if warm_up_variants else warm_up
+            output = _build_package(
+                date_str, persona_name, persona_role, lesson_number, scenario,
+                wu, speaking_prompt, persona_prompt, carry,
+                drill_session=k, drill_total=drill_total,
+            )
+            print(output)
+            print()
+
+            if not args.dry_run and args.dropbox:
+                fname = _dropbox_filename(date_str, lesson_number, persona_name, scenario, k, drill_total)
+                dest = _write_dropbox(sync_cfg, fname, output)
+                print(f"✅ Drill {k}/{drill_total} written to Dropbox: {dest.name}", file=sys.stderr)
+
+            if first_output is None:
+                first_output = output
+
+        # Send only the first drill session to Telegram
+        if args.send and not args.dry_run and first_output:
+            _send_telegram(first_output)
+            print(f"✅ Drill 1/{drill_total} sent to Telegram.", file=sys.stderr)
+
+    else:
+        output = _build_package(
+            date_str, persona_name, persona_role, lesson_number, scenario,
+            warm_up, speaking_prompt, persona_prompt, carry,
+        )
+        print(output)
+
+        if not args.dry_run and args.dropbox:
+            fname = _dropbox_filename(date_str, lesson_number, persona_name, scenario)
+            dest = _write_dropbox(sync_cfg, fname, output)
+            print(f"✅ Written to Dropbox: {dest.name}", file=sys.stderr)
+
+        if args.send and not args.dry_run:
+            _send_telegram(output)
+            print("✅ Sent to Telegram.", file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+get_german_session.py — Assemble and print today's German practice session package.
+
+Usage:
+  python get_german_session.py --base-dir language/german/
+  python get_german_session.py --base-dir language/german/ --date 2026-04-25
+  python get_german_session.py --base-dir language/german/ --dry-run
+"""
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _slug(name: str) -> str:
+    """'Frau Novak' → 'frau_novak', 'Dr. Huber' → 'dr_huber'"""
+    name = re.sub(r'[^\w\s]', '', name)
+    return '_'.join(name.lower().split())
+
+
+def _find_prompt_file(prompts_dir: Path, persona_name: str) -> Path | None:
+    slug = _slug(persona_name)
+    exact = prompts_dir / f"{slug}.txt"
+    if exact.exists():
+        return exact
+    matches = sorted(prompts_dir.glob(f"{slug}*.txt"))
+    return matches[0] if matches else None
+
+
+def _load_lesson(lessons_dir: Path, date_str: str) -> dict | None:
+    today = lessons_dir / f"{date_str}_lesson.json"
+    if today.exists():
+        return json.loads(today.read_text(encoding='utf-8'))
+    all_lessons = sorted(lessons_dir.glob('*_lesson.json'))
+    if all_lessons:
+        return json.loads(all_lessons[-1].read_text(encoding='utf-8'))
+    return None
+
+
+def _carry_forward(lesson: dict, progress: dict) -> str:
+    if lesson.get('carry_forward_errors'):
+        return lesson['carry_forward_errors'][0]
+
+    counts = progress.get('cumulative_error_counts', {})
+    if not counts:
+        return "None yet — first session!"
+
+    top_error = max(counts, key=counts.get)
+    count = counts[top_error]
+
+    vocab = progress.get('vocabulary_seen', [])
+    if top_error == 'vocabulary' and vocab:
+        return f"vocabulary ({count} total, e.g. {vocab[-1]})"
+
+    return f"{top_error} ({count} total)"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Assemble today's German practice session package.")
+    parser.add_argument('--base-dir', default='language/german/', help='Path to language/german/ directory')
+    parser.add_argument('--date', help='Override date (YYYY-MM-DD, for testing)')
+    parser.add_argument('--dry-run', action='store_true', help='Print output without sending anywhere')
+    args = parser.parse_args()
+
+    base = Path(args.base_dir)
+    config_dir = base / 'config'
+    prompts_dir = config_dir / 'prompts'
+    lessons_dir = base / 'lessons'
+
+    date_str = args.date or datetime.now(timezone.utc).strftime('%Y-%m-%d')
+
+    domain = {}
+    domain_file = config_dir / 'domain.json'
+    if domain_file.exists():
+        domain = json.loads(domain_file.read_text(encoding='utf-8'))
+
+    progress = {}
+    progress_file = base / 'progress.json'
+    if progress_file.exists():
+        progress = json.loads(progress_file.read_text(encoding='utf-8'))
+
+    personas = []
+    personas_file = config_dir / 'personas.json'
+    if personas_file.exists():
+        personas = json.loads(personas_file.read_text(encoding='utf-8'))
+
+    lesson = _load_lesson(lessons_dir, date_str)
+
+    if lesson is None:
+        persona_name = domain.get('active_persona', 'Frau Berger')
+        lesson_number = domain.get('current_lesson_number', 1)
+        scenario = 'bakery_order'
+        warm_up = ''
+        speaking_prompt = ''
+    else:
+        persona_name = lesson.get('persona', domain.get('active_persona', 'Frau Berger'))
+        lesson_number = lesson.get('lesson_number', domain.get('current_lesson_number', 1))
+        scenario = lesson.get('scenario', 'bakery_order')
+        warm_up = lesson.get('warm_up', '')
+        speaking_prompt = lesson.get('speaking_prompt', '')
+
+    persona_role = next((p['role'] for p in personas if p['name'] == persona_name), 'Unknown')
+
+    prompt_file = _find_prompt_file(prompts_dir, persona_name)
+    if prompt_file is None:
+        slug = _slug(persona_name)
+        print(f"Persona prompt file not found: {prompts_dir}/{slug}*.txt", file=sys.stderr)
+        sys.exit(1)
+
+    persona_prompt = prompt_file.read_text(encoding='utf-8').strip()
+    carry = _carry_forward(lesson or {}, progress)
+
+    lines = [
+        f"📚 Today's German Session — Lesson {lesson_number}",
+        f"Persona: {persona_name} — {persona_role}",
+        f"Scenario: {scenario}",
+        f"Carry forward: {carry}",
+    ]
+    if warm_up:
+        lines.append(f"Warm-up: {warm_up}")
+    if speaking_prompt:
+        lines.append(f"Prompt: {speaking_prompt}")
+
+    lines += [
+        "",
+        "─── PASTE INTO GROK OR CLAUDE ───",
+        "",
+        persona_prompt,
+        "",
+        "─── HOW TO END THE SESSION ───",
+        "",
+        'When finished say: "End session. Give me a clean transcript."',
+        "",
+        "Format:",
+        "---SESSION---",
+        f"Date: {date_str}",
+        f"Persona: {persona_name}",
+        f"Scenario: {scenario}",
+        "Duration: [number only, e.g. 12]",
+        "Mode: voice",
+        "",
+        f"{persona_name}: [turn text]",
+        "Robert: [turn text]",
+        "[continue alternating turns...]",
+        "---END---",
+        "",
+        "Send transcript to @minimoi_cmd_bot to process.",
+    ]
+
+    print('\n'.join(lines))
+
+
+if __name__ == '__main__':
+    main()

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -25,9 +25,6 @@ except ImportError:
     requests = None
 
 
-_TG_MAX = 4000  # Telegram hard limit is 4096; stay under with margin
-
-
 def _send_telegram(text: str) -> None:
     if keyring is None or requests is None:
         print("⚠️  keyring/requests not available — cannot send to Telegram.", file=sys.stderr)
@@ -37,16 +34,59 @@ def _send_telegram(text: str) -> None:
     if not token or not chat_id:
         print("⚠️  Telegram credentials not found in Keychain (telegram/polling_bot_token, telegram/chat_id).", file=sys.stderr)
         sys.exit(1)
-    chunks = [text[i:i + _TG_MAX] for i in range(0, len(text), _TG_MAX)]
-    for chunk in chunks:
-        resp = requests.post(
-            f"https://api.telegram.org/bot{token}/sendMessage",
-            json={"chat_id": chat_id, "text": chunk, "disable_web_page_preview": True},
-            timeout=30,
+    resp = requests.post(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        json={"chat_id": chat_id, "text": text, "disable_web_page_preview": True},
+        timeout=30,
+    )
+    if not resp.ok:
+        print(f"⚠️  Telegram send failed: {resp.status_code} {resp.text[:200]}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _get_anthropic_client():
+    try:
+        import anthropic
+        import keyring as kr
+        api_key = kr.get_password("anthropic", "api_key") or ""
+        return anthropic.Anthropic(api_key=api_key)
+    except Exception as e:
+        raise RuntimeError(f"Cannot create Anthropic client: {e}")
+
+
+def _enforce_length(prompt: str, limit: int) -> str:
+    if len(prompt) <= limit:
+        return prompt
+    original_len = len(prompt)
+    try:
+        client = _get_anthropic_client()
+        response = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=2000,
+            messages=[{
+                "role": "user",
+                "content": (
+                    f"The following German practice session prompt is {original_len} "
+                    f"characters, exceeding the {limit} character delivery limit. "
+                    f"Shorten it to under {limit} characters by:\n"
+                    f"1. Condensing the vocabulary list — keep the 5 most important "
+                    f"items, remove the rest\n"
+                    f"2. Shortening the persona description — keep name, role, key "
+                    f"traits; remove redundant detail\n"
+                    f"DO NOT touch: the === SESSION INSTRUCTIONS === block, the "
+                    f"=== HOW TO END === block, or the lesson metadata lines "
+                    f"(persona, scenario, carry-forward, warm-up, prompt).\n"
+                    f"Return only the revised prompt — no commentary.\n\n"
+                    f"{prompt}"
+                ),
+            }],
         )
-        if not resp.ok:
-            print(f"⚠️  Telegram send failed: {resp.status_code} {resp.text[:200]}", file=sys.stderr)
-            sys.exit(1)
+        revised = response.content[0].text.strip()
+        print(f"⚠️  Prompt revised by Haiku: {original_len} → {len(revised)} chars", file=sys.stderr)
+        return revised
+    except Exception as e:
+        print(f"⚠️  Haiku revision failed ({e}) — sending full prompt", file=sys.stderr)
+        return prompt
 
 
 def _load_sync_config() -> dict:
@@ -113,44 +153,52 @@ UNIVERSAL_HEADER = """\
 === SESSION INSTRUCTIONS — READ BEFORE STARTING ===
 
 You are playing a character in a German language practice session.
-Follow these rules exactly, regardless of any other instructions:
+These rules override everything else. Follow them exactly.
 
-1. GENDER: Play the character exactly as described below. Never switch gender.
-2. SCENARIO: Follow the scenario setup exactly. If it says phone call, answer
-   the phone. If it says I walk in, greet me as I arrive. Do not improvise
-   the setting.
-3. NO NAME PREFIX: Do not announce your name before each turn. Speak directly
-   and naturally as the character would in real life. Wrong: "Klaus: Guten
-   Abend!" Correct: "Guten Abend!"
-4. LANGUAGE: Always respond in German. Never switch to English unless I
+0. VOICE AND GENDER: You are playing the character exactly as described
+   below — including gender. If the character is male, use a male voice
+   and male mannerisms throughout. Never switch gender. Never use a female
+   voice for a male character. This is non-negotiable.
+
+1. SCENARIO AND MEDIUM: Follow the scenario setup exactly, including the
+   communication medium. If it says "phone call" or "making a reservation
+   by phone", you answer the phone — I am not standing in front of you.
+   If it says I walk in, greet me as I arrive in person. Never change the
+   setting or medium mid-session.
+
+2. NO NAME PREFIX: Do not announce your name before each turn. Speak
+   directly and naturally as the character would in real life.
+   Wrong: "Klaus: Guten Abend!"
+   Correct: "Guten Abend!"
+
+3. LANGUAGE: Always respond in German. Never switch to English unless I
    explicitly say "English please."
-5. CORRECTIONS: If I make a grammatical error, gently use the correct form
-   naturally in your response. Do not break character to explain.
-6. START TRIGGER: Do not begin the scenario until I say exactly:
+
+4. CORRECTIONS: If I make a grammatical error, gently use the correct
+   form naturally in your response. Do not break character to explain.
+
+5. START TRIGGER: Do not begin the scenario until I say exactly:
    "Start today's session."
-7. STAY IN CHARACTER: Do not comment on the exercise, the instructions, or
-   your role. You are the character. Respond only as the character would.
+
+6. STAY IN CHARACTER: Do not comment on the exercise, the instructions,
+   or your role. You are the character. Respond only as the character
+   would.
 
 === CHARACTER AND SCENARIO BELOW ===""".strip()
 
 UNIVERSAL_FOOTER = """\
 === HOW TO END THIS SESSION ===
 
-OPTION A — If ending by voice:
-Say out loud: "End session."
-Then switch to text mode and say: "Give me the transcript now."
+When the session is over, say: "End session."
 
-OPTION B — If ending by text:
-Type: "End session. Give me the transcript."
-
-In both cases, output ONLY the following block — nothing before, nothing
-after, no commentary:
+At that moment, switch to text and output ONLY the following block —
+nothing before it, nothing after it, no commentary:
 
 ---SESSION---
 Date: [today's date as YYYY-MM-DD]
 Persona: [character name]
 Scenario: [scenario_label]
-Duration: [your estimate in minutes, number only — e.g. 12]
+Duration: [number only — e.g. 12]
 Mode: voice
 
 [Character name]: [their exact words]
@@ -159,11 +207,10 @@ Robert: [your exact words]
 ---END---
 
 RULES FOR THE TRANSCRIPT:
-- Include every turn in order. Do not skip or summarize any turn.
-- Use --- (three hyphens) not em-dashes (—) for the SESSION and END markers.
-- Duration is a number only — no "minutes" or other text.
-- Do not add any text before ---SESSION--- or after ---END---.
-- If you are unsure of exact wording, write your best reconstruction.""".strip()
+- Include every turn in order. Do not skip or summarize.
+- Use --- (three hyphens) not em-dashes (—) for ---SESSION--- and ---END---.
+- Duration is a number only. No "minutes" or other text.
+- Nothing before ---SESSION---. Nothing after ---END---.""".strip()
 
 
 def _dropbox_filename(date_str: str, lesson_number: int, persona_name: str,
@@ -275,7 +322,8 @@ def main():
     persona_prompt = prompt_file.read_text(encoding='utf-8').strip()
     carry = _carry_forward(lesson or {}, progress)
 
-    sync_cfg = _load_sync_config() if args.dropbox else {}
+    sync_cfg = _load_sync_config()
+    max_chars = sync_cfg.get("max_prompt_chars", 4000)
 
     drill_total = args.drill or 0
 
@@ -294,6 +342,8 @@ def main():
                 wu, speaking_prompt, persona_prompt, carry,
                 drill_session=k, drill_total=drill_total,
             )
+            if not args.dry_run:
+                output = _enforce_length(output, max_chars)
             print(output)
             print()
 
@@ -315,6 +365,8 @@ def main():
             date_str, persona_name, persona_role, lesson_number, scenario,
             warm_up, speaking_prompt, persona_prompt, carry,
         )
+        if not args.dry_run:
+            output = _enforce_length(output, max_chars)
         print(output)
 
         if not args.dry_run and args.dropbox:

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -146,9 +146,14 @@ def _load_lesson(lessons_dir: Path, date_str: str) -> dict | None:
     return None
 
 
+def _strip_session_metadata(text: str) -> str:
+    """Remove trailing '— session YYYY-MM-DD ...' from carry-forward strings."""
+    return re.sub(r'\s*—\s*session\s+\d{4}-\d{2}-\d{2}.*$', '', text).strip()
+
+
 def _carry_forward(lesson: dict, progress: dict) -> str:
     if lesson.get('carry_forward_errors'):
-        return lesson['carry_forward_errors'][0]
+        return _strip_session_metadata(lesson['carry_forward_errors'][0])
 
     counts = progress.get('cumulative_error_counts', {})
     if not counts:

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -247,10 +247,16 @@ def _dropbox_filename(date_str: str, lesson_number: int, persona_name: str,
 def _build_package(date_str: str, persona_name: str, persona_role: str,
                    lesson_number: int, scenario: str, warm_up: str,
                    speaking_prompt: str, persona_prompt: str, carry: str,
-                   drill_session: int = 0, drill_total: int = 0) -> str:
+                   drill_session: int = 0, drill_total: int = 0,
+                   writing_mode: bool = False) -> str:
     drill_mode = drill_total > 0
 
-    lines = [
+    lines = []
+    if writing_mode:
+        lines.append("⌨️ WRITING SESSION — Add Mode: writing to transcript header.")
+        lines.append("")
+
+    lines += [
         f"📚 Today's German Session — Lesson {lesson_number}",
         f"Persona: {persona_name} — {persona_role}",
         f"Scenario: {scenario}",
@@ -264,6 +270,8 @@ def _build_package(date_str: str, persona_name: str, persona_role: str,
         lines.append(f"Prompt: {speaking_prompt}")
 
     footer = UNIVERSAL_FOOTER
+    if writing_mode:
+        footer = footer.replace("Mode: voice", "Mode: writing")
     if drill_mode:
         footer = footer.replace(
             "Mode: voice",
@@ -290,6 +298,7 @@ def main():
     parser.add_argument('--dropbox', action='store_true', help='Write prompt file(s) to Dropbox prompts dir')
     parser.add_argument('--drill', type=int, metavar='N', help='Generate N drill session prompts (one per session)')
     parser.add_argument('--drill-session', type=int, metavar='K', help='Generate prompt for drill session K only (requires --drill N)')
+    parser.add_argument('--writing', action='store_true', help='Writing session mode — sets Mode: writing in transcript footer')
     args = parser.parse_args()
 
     base = Path(args.base_dir)
@@ -361,6 +370,7 @@ def main():
                 date_str, persona_name, persona_role, lesson_number, scenario,
                 wu, speaking_prompt, persona_prompt, carry,
                 drill_session=k, drill_total=drill_total,
+                writing_mode=args.writing,
             )
             if not args.dry_run:
                 output = _enforce_length(output, max_chars, persona_name)
@@ -384,6 +394,7 @@ def main():
         output = _build_package(
             date_str, persona_name, persona_role, lesson_number, scenario,
             warm_up, speaking_prompt, persona_prompt, carry,
+            writing_mode=args.writing,
         )
         if not args.dry_run:
             output = _enforce_length(output, max_chars)

--- a/_NewDomains/language-german/get_german_session.py
+++ b/_NewDomains/language-german/get_german_session.py
@@ -25,6 +25,9 @@ except ImportError:
     requests = None
 
 
+_TG_MAX = 4000  # Telegram hard limit is 4096; stay under with margin
+
+
 def _send_telegram(text: str) -> None:
     if keyring is None or requests is None:
         print("⚠️  keyring/requests not available — cannot send to Telegram.", file=sys.stderr)
@@ -34,14 +37,16 @@ def _send_telegram(text: str) -> None:
     if not token or not chat_id:
         print("⚠️  Telegram credentials not found in Keychain (telegram/polling_bot_token, telegram/chat_id).", file=sys.stderr)
         sys.exit(1)
-    resp = requests.post(
-        f"https://api.telegram.org/bot{token}/sendMessage",
-        json={"chat_id": chat_id, "text": text, "disable_web_page_preview": True},
-        timeout=30,
-    )
-    if not resp.ok:
-        print(f"⚠️  Telegram send failed: {resp.status_code} {resp.text[:200]}", file=sys.stderr)
-        sys.exit(1)
+    chunks = [text[i:i + _TG_MAX] for i in range(0, len(text), _TG_MAX)]
+    for chunk in chunks:
+        resp = requests.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            json={"chat_id": chat_id, "text": chunk, "disable_web_page_preview": True},
+            timeout=30,
+        )
+        if not resp.ok:
+            print(f"⚠️  Telegram send failed: {resp.status_code} {resp.text[:200]}", file=sys.stderr)
+            sys.exit(1)
 
 
 def _load_sync_config() -> dict:
@@ -104,6 +109,63 @@ def _carry_forward(lesson: dict, progress: dict) -> str:
     return f"{top_error} ({count} total)"
 
 
+UNIVERSAL_HEADER = """\
+=== SESSION INSTRUCTIONS — READ BEFORE STARTING ===
+
+You are playing a character in a German language practice session.
+Follow these rules exactly, regardless of any other instructions:
+
+1. GENDER: Play the character exactly as described below. Never switch gender.
+2. SCENARIO: Follow the scenario setup exactly. If it says phone call, answer
+   the phone. If it says I walk in, greet me as I arrive. Do not improvise
+   the setting.
+3. NO NAME PREFIX: Do not announce your name before each turn. Speak directly
+   and naturally as the character would in real life. Wrong: "Klaus: Guten
+   Abend!" Correct: "Guten Abend!"
+4. LANGUAGE: Always respond in German. Never switch to English unless I
+   explicitly say "English please."
+5. CORRECTIONS: If I make a grammatical error, gently use the correct form
+   naturally in your response. Do not break character to explain.
+6. START TRIGGER: Do not begin the scenario until I say exactly:
+   "Start today's session."
+7. STAY IN CHARACTER: Do not comment on the exercise, the instructions, or
+   your role. You are the character. Respond only as the character would.
+
+=== CHARACTER AND SCENARIO BELOW ===""".strip()
+
+UNIVERSAL_FOOTER = """\
+=== HOW TO END THIS SESSION ===
+
+OPTION A — If ending by voice:
+Say out loud: "End session."
+Then switch to text mode and say: "Give me the transcript now."
+
+OPTION B — If ending by text:
+Type: "End session. Give me the transcript."
+
+In both cases, output ONLY the following block — nothing before, nothing
+after, no commentary:
+
+---SESSION---
+Date: [today's date as YYYY-MM-DD]
+Persona: [character name]
+Scenario: [scenario_label]
+Duration: [your estimate in minutes, number only — e.g. 12]
+Mode: voice
+
+[Character name]: [their exact words]
+Robert: [your exact words]
+[continue alternating turns in order...]
+---END---
+
+RULES FOR THE TRANSCRIPT:
+- Include every turn in order. Do not skip or summarize any turn.
+- Use --- (three hyphens) not em-dashes (—) for the SESSION and END markers.
+- Duration is a number only — no "minutes" or other text.
+- Do not add any text before ---SESSION--- or after ---END---.
+- If you are unsure of exact wording, write your best reconstruction.""".strip()
+
+
 def _dropbox_filename(date_str: str, lesson_number: int, persona_name: str,
                       scenario: str, drill_session: int = 0, drill_total: int = 0) -> str:
     ts = datetime.now().strftime("%H%M")
@@ -134,35 +196,20 @@ def _build_package(date_str: str, persona_name: str, persona_role: str,
     if speaking_prompt:
         lines.append(f"Prompt: {speaking_prompt}")
 
+    footer = UNIVERSAL_FOOTER
+    if drill_mode:
+        footer = footer.replace(
+            "Mode: voice",
+            f"Mode: voice\nDrill: true\nDrill-Session: {drill_session} of {drill_total}",
+        )
+
     lines += [
         "",
-        "─── PASTE INTO GROK OR CLAUDE ───",
+        UNIVERSAL_HEADER,
         "",
         persona_prompt,
         "",
-        "─── HOW TO END THE SESSION ───",
-        "",
-        'When finished say: "End session. Give me a clean transcript."',
-        "",
-        "Format:",
-        "---SESSION---",
-        f"Date: {date_str}",
-        f"Persona: {persona_name}",
-        f"Scenario: {scenario}",
-        "Duration: [number only, e.g. 12]",
-        "Mode: voice",
-    ]
-    if drill_mode:
-        lines.append("Drill: true")
-        lines.append(f"Drill-Session: {drill_session} of {drill_total}")
-    lines += [
-        "",
-        f"{persona_name}: [turn text]",
-        "Robert: [turn text]",
-        "[continue alternating turns...]",
-        "---END---",
-        "",
-        "Send transcript to @minimoi_cmd_bot to process.",
+        footer,
     ]
     return '\n'.join(lines)
 

--- a/_NewDomains/language-german/import_cards.py
+++ b/_NewDomains/language-german/import_cards.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+import_cards.py — Push unimported German Anki CSVs to Anki via AnkiConnect.
+
+Usage:
+  python3 import_cards.py
+
+Idempotent: tracks imported files in imported_files.txt; re-runs are safe.
+Requires Anki to be open with AnkiConnect add-on running on port 8765.
+"""
+import csv
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ANKI_URL   = "http://localhost:8765"
+DECK_NAME  = "German"
+MODEL_NAME = "Basic"
+ANKI_DIR   = Path(__file__).parent / "language/german/anki"
+TRACKER    = Path(__file__).parent / "imported_files.txt"
+
+
+def clean_back(raw: str) -> str:
+    return raw.split(" \u2014 ")[0].strip()
+
+
+def load_tracker() -> set[str]:
+    if not TRACKER.exists():
+        return set()
+    return set(TRACKER.read_text(encoding="utf-8").splitlines())
+
+
+def mark_imported(filename: str) -> None:
+    with open(TRACKER, "a", encoding="utf-8") as f:
+        f.write(filename + "\n")
+
+
+def parse_csv(path: Path) -> list[dict]:
+    notes = []
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        next(reader)  # skip header
+        for i, row in enumerate(reader, start=2):
+            if len(row) != 3:
+                print(f"  ⚠️  {path.name} row {i}: expected 3 columns, got {len(row)} — skipped")
+                continue
+            front, back, tags_raw = row
+            notes.append({
+                "deckName": DECK_NAME,
+                "modelName": MODEL_NAME,
+                "fields": {"Front": front, "Back": clean_back(back)},
+                "tags": tags_raw.split(),
+            })
+    return notes
+
+
+def ankiconnect(action: str, **params) -> dict:
+    payload = json.dumps({"action": action, "version": 6, "params": params}).encode()
+    req = urllib.request.Request(
+        ANKI_URL, data=payload, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as r:
+            return json.loads(r.read())
+    except urllib.error.URLError as e:
+        print(f"❌ AnkiConnect unreachable: {e}")
+        raise SystemExit(1)
+
+
+def add_notes(notes: list[dict]) -> tuple[int, int]:
+    resp = ankiconnect("addNotes", notes=notes)
+    ids = resp.get("result") or []
+    added = sum(1 for x in ids if x is not None)
+    dupes = sum(1 for x in ids if x is None)
+    return added, dupes
+
+
+def main() -> None:
+    imported = load_tracker()
+    pending = sorted(f for f in ANKI_DIR.glob("*.csv") if f.name not in imported)
+
+    if not pending:
+        print("Nothing new to import.")
+        return
+
+    total_files = total_added = total_dupes = 0
+
+    for csv_path in pending:
+        notes = parse_csv(csv_path)
+        if not notes:
+            print(f"  ⚠️  {csv_path.name}: no valid rows — skipping")
+            continue
+        added, dupes = add_notes(notes)
+        if added == 0 and dupes == 0:
+            print(f"  ❌ {csv_path.name}: AnkiConnect returned no results — deck may not exist. Not marked as imported.")
+            continue
+        mark_imported(csv_path.name)
+        total_files += 1
+        total_added += added
+        total_dupes += dupes
+        dupe_note = f", {dupes} duplicate(s)" if dupes else ""
+        print(f"  ✅ {csv_path.name}: {added} card(s) added{dupe_note}")
+
+    print(f"\nImported {total_files} file(s), {total_added} card(s) added.")
+
+
+if __name__ == "__main__":
+    main()

--- a/_NewDomains/language-german/imported_files.txt
+++ b/_NewDomains/language-german/imported_files.txt
@@ -1,0 +1,6 @@
+2026-04-19_anki.csv
+2026-04-20_anki.csv
+2026-04-21_anki.csv
+2026-04-23_anki.csv
+2026-04-24_anki.csv
+2026-04-25 Persona: Frau Novak Scenario: ask_medicine Duration: 14 Mode: voice_anki.csv

--- a/_NewDomains/language-german/language/german/config/domain.json
+++ b/_NewDomains/language-german/language/german/config/domain.json
@@ -1,8 +1,8 @@
 {
   "domain": "german",
   "active": true,
-  "current_lesson_number": 1,
-  "active_persona": "Frau Berger",
+  "current_lesson_number": 28,
+  "active_persona": "Anna",
   "level": "A2-B1",
   "target": "B1 spoken confidence for Vienna trip",
   "trip_date": "2026-05-10",

--- a/_NewDomains/language-german/language/german/config/personas.json
+++ b/_NewDomains/language-german/language/german/config/personas.json
@@ -9,7 +9,13 @@
       "neighborhood_chat": "You've just picked up your order and Frau Berger wants to chat. She asks how you're finding Vienna. Talk about the neighborhood, what you've seen, and where you're headed next."
     },
     "style": "casual, forgiving, gentle in-character corrections",
-    "difficulty": "beginner-friendly"
+    "difficulty": "beginner-friendly",
+    "warm_up_variants": [
+      "Order a Semmel and ask for the price.",
+      "Ask what's fresh today, then order a Kipferl.",
+      "Order a Mohnflesserl and ask if they have Topfenstrudel.",
+      "Ask for two Semmeln and a Salzstangerl, then pay with exact change."
+    ]
   },
   {
     "name": "Herr Fischer",
@@ -23,7 +29,13 @@
       "directions": "You're in the hotel lobby and need to get somewhere in the city. Ask Herr Fischer how to get to the Naschmarkt by U-Bahn. Confirm the line number and how many stops."
     },
     "style": "formal, clear, standard Hochdeutsch",
-    "difficulty": "intermediate"
+    "difficulty": "intermediate",
+    "warm_up_variants": [
+      "Ask what time breakfast starts and where it's served.",
+      "Ask Herr Fischer to recommend a good restaurant nearby.",
+      "Request a wake-up call for 7am tomorrow.",
+      "Ask if the hotel has a gym and what the opening hours are."
+    ]
   },
   {
     "name": "Maria",
@@ -36,7 +48,13 @@
       "cafe_meal": "It's lunchtime. Order a full small meal from the Tageskarte (daily menu). Ask what the soup of the day is, then order a main and a drink."
     },
     "style": "casual, slightly fast, informal",
-    "difficulty": "intermediate"
+    "difficulty": "intermediate",
+    "warm_up_variants": [
+      "Order a Melange and a Kipferl.",
+      "Order a Verlängerter and ask for the Tageskarte.",
+      "Ask if the Gugelhupf is fresh, then order a Kleiner Brauner.",
+      "Ask for a table for two, order drinks, and ask for the bill."
+    ]
   },
   {
     "name": "Dr. Huber",
@@ -49,7 +67,13 @@
       "museum_navigation": "You're lost in the museum. Ask Dr. Huber how to find the Egyptian collection and where the toilets are. He'll give directions — confirm you understood."
     },
     "style": "formal, informative, complete sentences",
-    "difficulty": "intermediate-advanced"
+    "difficulty": "intermediate-advanced",
+    "warm_up_variants": [
+      "Ask Dr. Huber who painted the most famous work in this room.",
+      "Ask when the museum was built and who commissioned it.",
+      "Ask which collection he personally finds most interesting.",
+      "Ask Dr. Huber to explain one small detail in the painting in front of you."
+    ]
   },
   {
     "name": "Stefan",
@@ -62,7 +86,13 @@
       "confirm_stop": "You're on the U4 and unsure if you've missed your stop. Ask the person next to you (Stefan) whether Karlsplatz is the next stop. He'll help you figure it out."
     },
     "style": "casual, normal speed, colloquial",
-    "difficulty": "intermediate"
+    "difficulty": "intermediate",
+    "warm_up_variants": [
+      "Ask Stefan how to get to the Naschmarkt on foot.",
+      "Ask which U-Bahn line goes to the Prater.",
+      "Ask Stefan how long it takes to walk to Schönbrunn from here.",
+      "Ask if the next train on this platform goes toward the city centre."
+    ]
   },
   {
     "name": "Frau Novak",
@@ -75,7 +105,13 @@
       "understand_instructions": "Frau Novak hands you medicine with instructions. Ask her to explain how often to take it and whether you can take it with food. Confirm you understood."
     },
     "style": "formal, precise, calm",
-    "difficulty": "intermediate"
+    "difficulty": "intermediate",
+    "warm_up_variants": [
+      "Ask for something for a mild headache, no prescription.",
+      "Ask Frau Novak if she has throat lozenges and which brand she recommends.",
+      "Ask whether ibuprofen or paracetamol is better for a fever.",
+      "Ask if you need a prescription for the medicine she's recommending."
+    ]
   },
   {
     "name": "Klaus",
@@ -89,7 +125,13 @@
       "pay_bill": "Dinner is done. Get Klaus's attention and ask for the bill. He'll tell you the total — pay by card and say goodbye politely."
     },
     "style": "formal, slightly elevated, Austrian formality",
-    "difficulty": "intermediate-advanced"
+    "difficulty": "intermediate-advanced",
+    "warm_up_variants": [
+      "Ask Klaus what today's Tagesgericht (dish of the day) is.",
+      "Ask whether the Tafelspitz is available this evening.",
+      "Ask Klaus to describe the difference between two starters.",
+      "Ask for still water and a bread basket before ordering."
+    ]
   },
   {
     "name": "Anna",
@@ -103,6 +145,12 @@
       "report_problem": "Something in the apartment isn't working — the hot water or the internet. Call Anna to report it. Describe the problem clearly and ask when it can be fixed."
     },
     "style": "casual, encouraging, patient",
-    "difficulty": "beginner-friendly"
+    "difficulty": "beginner-friendly",
+    "warm_up_variants": [
+      "Ask Anna where to put the rubbish and which bins are for recycling.",
+      "Ask what the checkout time is and whether you can leave bags after.",
+      "Ask Anna for the WiFi password and how to connect the TV.",
+      "Ask if there are any house rules you should know about."
+    ]
   }
 ]

--- a/_NewDomains/language-german/language/german/config/prompts/anna_airbnb.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/anna_airbnb.txt
@@ -1,0 +1,28 @@
+# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max
+
+You are now my dedicated German language practice partner for my trip to Vienna in 3 weeks.
+
+Your name is **Anna**, a friendly and practical Airbnb host in her 30s living in Vienna. You are warm, patient, and encouraging — you want your guest to feel comfortable. You speak natural, everyday Austrian German. You use informal du form — you are a host welcoming a guest into your home. You are helpful and gently correct me when I make mistakes, but you never switch to English unless I explicitly ask.
+
+Rules:
+- Always respond in German first.
+- Be warm, patient, and encouraging — this is a welcoming environment.
+- If I make a mistake, naturally use the correct form in your response.
+- Stay in character as Anna showing a guest around her apartment.
+- Use du form throughout — it is your home and you are being friendly.
+
+We are practicing real-life situations: apartment handoff and key handover, asking about appliances, getting neighborhood recommendations, reporting a small problem.
+
+Useful vocabulary for context:
+- die Waschmaschine: washing machine
+- der Schlüssel: key
+- die Heizung: heating
+- das WLAN-Passwort: WiFi password
+- der Müll: rubbish/trash
+- Wo ist der nächste Supermarkt?: Where is the nearest supermarket?
+- Gibt es etwas, das ich wissen sollte?: Is there anything I should know?
+- Wie funktioniert das?: How does this work?
+
+Start every new session by greeting me as if I just arrived at your apartment with my luggage for a week's stay.
+
+Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/prompts/dr_huber_museum.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/dr_huber_museum.txt
@@ -1,0 +1,18 @@
+# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max
+
+You are now my dedicated German language practice partner for my trip to Vienna in 3 weeks.
+
+Your name is **Dr. Huber**, an enthusiastic and knowledgeable museum guide in his 50s working at the Kunsthistorisches Museum in Vienna. You speak in complete, well-formed sentences — clear, educated Austrian German. You love talking about art and history and will happily explain things in detail. You use formal Sie form. You are helpful and gently correct me when I make mistakes, but you never switch to English unless I explicitly ask.
+
+Rules:
+- Always respond in German first.
+- Speak in complete sentences — you are an educator.
+- If I make a mistake, naturally use the correct form in your response.
+- Stay in character as Dr. Huber giving a tour or answering visitor questions.
+- Use formal Sie form throughout.
+
+We are practicing real-life situations: asking about an exhibit, requesting recommendations, navigating the museum, asking follow-up questions about art or history.
+
+Start every new session by greeting me as if I just approached you in the museum lobby asking for help.
+
+Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/prompts/frau_berger_bakery.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/frau_berger_bakery.txt
@@ -1,0 +1,18 @@
+# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max
+
+You are now my dedicated German language practice partner for my trip to Vienna in 3 weeks.
+
+Your name is **Frau Berger**, a warm, patient, friendly bakery owner in her 50s from the 2. Bezirk near the Naschmarkt. You speak natural, everyday Austrian German (not overly formal Hochdeutsch). You are helpful and gently correct me when I make mistakes, but you never switch to English unless I explicitly ask.
+
+Rules:
+- Always respond in German first.
+- Keep responses natural and conversational.
+- If I make a mistake, gently repeat the correct version in your next reply.
+- Stay in character as Frau Berger.
+- Use common Viennese expressions when it feels natural (Servus, Grüß Gott, freilich, eh, na).
+
+We are practicing real-life situations: ordering bread and pastries, small talk, asking questions about the neighborhood.
+
+Start every new session by greeting me as if I just walked into your bakery in the morning.
+
+Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/prompts/frau_novak_pharmacy.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/frau_novak_pharmacy.txt
@@ -1,0 +1,29 @@
+# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max
+
+You are now my dedicated German language practice partner for my trip to Vienna in 3 weeks.
+
+Your name is **Frau Novak**, a calm, precise, and professional pharmacist in her 40s working at an Apotheke in Vienna. You speak clear, careful German — not overly formal but precise, as a pharmacist should be. You use formal Sie form. You are helpful and gently correct me when I make mistakes, but you never switch to English unless I explicitly ask.
+
+Rules:
+- Always respond in German first.
+- Speak clearly and precisely — you want the patient to understand correctly.
+- If I make a mistake, gently use the correct form in your response.
+- Stay in character as Frau Novak at the pharmacy counter.
+- Use formal Sie form throughout.
+
+We are practicing real-life situations: asking for medicine, describing a mild symptom, understanding dosage instructions, asking about side effects.
+
+Useful vocabulary for context:
+- Kopfschmerzen: headache
+- Halsschmerzen: sore throat
+- Schnupfen: runny nose
+- Fieber: fever
+- Tabletten: tablets
+- Tropfen: drops
+- Salbe: ointment
+- rezeptfrei: without prescription
+- Wie oft soll ich das nehmen?: How often should I take this?
+
+Start every new session by greeting me as if I just walked up to the pharmacy counter.
+
+Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/prompts/herr_fischer_hotel.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/herr_fischer_hotel.txt
@@ -1,0 +1,20 @@
+# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max
+
+You are now my dedicated German language practice partner for my trip to Vienna in 3 weeks.
+
+Your name is **Herr Fischer**, a professional, efficient, and polite hotel receptionist in his 40s working at a mid-range hotel near the Ringstraße in Vienna. You speak clear, somewhat formal Austrian German — good standard Hochdeutsch with occasional Viennese politeness markers ("Bitte sehr", "Selbstverständlich", "Aber natürlich").
+
+You are helpful and gently correct me when I make mistakes, but you never switch to English unless I explicitly ask.
+
+Rules:
+- Always respond in German first.
+- Keep responses professional but warm — you are a good hotel receptionist.
+- If I make a mistake, gently use the correct form in your next reply without making it awkward.
+- Stay in character as Herr Fischer at the front desk.
+- Use formal Sie form throughout — this is a hotel, not a bakery.
+
+We are practicing real-life situations: hotel check-in, asking about amenities, reporting a room problem, asking for directions from the hotel.
+
+Start every new session by greeting me as if I just walked into the hotel lobby.
+
+Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/prompts/klaus_restaurant.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/klaus_restaurant.txt
@@ -1,0 +1,17 @@
+# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max
+
+Your name is **Klaus**, a formal and proud waiter in his 50s working at an upscale Viennese restaurant. You take your profession seriously and expect proper dining etiquette. You speak with slight Austrian formality — "Bitte sehr, der Herr", "Selbstverständlich", "Darf ich empfehlen". You use formal Sie form exclusively.
+
+We are practicing real-life situations: making a reservation, ordering a full meal, asking about the menu, ordering wine, paying the bill.
+
+Useful vocabulary for context:
+- die Speisekarte: menu
+- die Tageskarte: daily specials
+- das Hauptgericht: main course
+- die Vorspeise: starter
+- Ich hätte gerne: I would like (polite order form — use this always)
+- Zahlen bitte: the bill please
+
+Start every new session by greeting me as if I just arrived at the restaurant for dinner.
+
+Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/prompts/klaus_restaurant.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/klaus_restaurant.txt
@@ -12,6 +12,6 @@ Useful vocabulary for context:
 - Ich hätte gerne: I would like (polite order form — use this always)
 - Zahlen bitte: the bill please
 
-Start every new session by greeting me as if I just arrived at the restaurant for dinner.
+This is a phone call — answer the phone when I call to make a reservation.
 
 Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/prompts/maria_cafe.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/maria_cafe.txt
@@ -1,0 +1,24 @@
+# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max
+
+You are now my dedicated German language practice partner for my trip to Vienna in 3 weeks.
+
+Your name is **Maria**, a young café waitress in her late 20s working at a classic Viennese Kaffeehaus. You are friendly but slightly hurried — the café is busy. You speak natural, informal Austrian German with some Viennese slang. You use du form naturally. You are helpful and gently correct me when I make mistakes, but you never switch to English unless I explicitly ask.
+
+Rules:
+- Always respond in German first.
+- Keep responses natural and slightly fast-paced — you are busy but friendly.
+- If I make a mistake, weave the correct form naturally into your reply.
+- Stay in character as Maria.
+- Use Viennese café vocabulary: Melange, Verlängerter, Einspänner, Kleiner Brauner, Gugelhupf.
+
+We are practicing real-life situations: ordering coffee and food, asking for the bill, small talk about the café.
+
+Viennese coffee guide for reference:
+- Melange: coffee with steamed milk
+- Verlängerter: weaker espresso with hot water
+- Einspänner: espresso with whipped cream in a glass
+- Kleiner Brauner: small espresso with a splash of milk
+
+Start every new session by greeting me as if I just sat down at a table in the café.
+
+Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/prompts/stefan_ubahn.txt
+++ b/_NewDomains/language-german/language/german/config/prompts/stefan_ubahn.txt
@@ -1,0 +1,24 @@
+# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max
+
+You are now my dedicated German language practice partner for my trip to Vienna in 3 weeks.
+
+Your name is **Stefan**, a relaxed local Viennese man in his early 30s. You are happy to help a tourist but you speak at normal conversational speed — not slow, not fast. You use informal du form and natural Viennese speech. You are helpful and gently correct me when I make mistakes, but you never switch to English unless I explicitly ask.
+
+Rules:
+- Always respond in German first.
+- Speak at a natural, normal pace — not simplified for a learner.
+- If I make a mistake, naturally use the correct form in your response.
+- Stay in character as Stefan — a helpful local who knows Vienna well.
+- Use du form throughout.
+
+We are practicing real-life situations: asking for directions, figuring out which U-Bahn line to take, confirming a stop, navigating the city.
+
+Useful Vienna U-Bahn lines for context:
+- U1 (red): Stephansplatz, Schwedenplatz, Reumannplatz
+- U2 (purple): Museumsquartier, Karlsplatz, Schottenring
+- U3 (orange): Westbahnhof, Volkstheater, Stephansplatz
+- U4 (green): Schönbrunn, Kettenbrückengasse (Naschmarkt), Schwedenplatz
+
+Start every new session by greeting me as if I just approached you on a U-Bahn platform looking confused.
+
+Ready when I say "Start today's session".

--- a/_NewDomains/language-german/language/german/config/sync_config.json
+++ b/_NewDomains/language-german/language/german/config/sync_config.json
@@ -1,0 +1,15 @@
+{
+  "sync_provider": "dropbox_local",
+  "base_path": "~/Dropbox/German_Sessions",
+  "prompts_dir": "prompts",
+  "transcripts_inbox_dir": "transcripts/inbox",
+  "transcripts_processed_dir": "transcripts/processed",
+  "watcher_mode": "poll",
+  "poll_interval_seconds": 15,
+  "supported_extensions": [".txt"],
+  "pipeline_base_dir": "_NewDomains/language-german/language/german",
+  "send_telegram_on_start": true,
+  "send_telegram_on_success": true,
+  "send_telegram_on_error": true,
+  "keep_history_days": 9999
+}

--- a/_NewDomains/language-german/language/german/config/sync_config.json
+++ b/_NewDomains/language-german/language/german/config/sync_config.json
@@ -6,10 +6,13 @@
   "transcripts_processed_dir": "transcripts/processed",
   "watcher_mode": "poll",
   "poll_interval_seconds": 15,
-  "supported_extensions": [".txt"],
+  "supported_extensions": [
+    ".txt"
+  ],
   "pipeline_base_dir": "_NewDomains/language-german/language/german",
   "send_telegram_on_start": true,
   "send_telegram_on_success": true,
   "send_telegram_on_error": true,
-  "keep_history_days": 9999
+  "keep_history_days": 9999,
+  "max_prompt_chars": 4000
 }

--- a/_NewDomains/language-german/language/german/config/sync_config.json
+++ b/_NewDomains/language-german/language/german/config/sync_config.json
@@ -14,5 +14,6 @@
   "send_telegram_on_success": true,
   "send_telegram_on_error": true,
   "keep_history_days": 9999,
-  "max_prompt_chars": 4000
+  "max_prompt_chars": 4000,
+  "agent_mode": "direct"
 }

--- a/_NewDomains/language-german/parse_transcript.py
+++ b/_NewDomains/language-german/parse_transcript.py
@@ -66,6 +66,29 @@ def _parse_header(lines: list) -> dict:
     return fields
 
 
+# Matches "Speaker Name:" at turn boundaries within a single-line dump.
+# Speaker names are 1-3 words, each word starts with a capital letter,
+# optionally prefixed with a title abbreviation ending in a period (e.g. Dr.).
+_INLINE_SPEAKER_RE = re.compile(
+    r'(?:^|(?<=\s))'
+    r'(?:(?:Dr|Frau|Herr|Prof)\.\s+)?'
+    r'(?:[A-ZÄÖÜ][a-zäöüß]+(?:\s+[A-ZÄÖÜ][a-zäöüß]+)?)'
+    r':'
+)
+
+
+def _split_inline_turns(line: str) -> list:
+    """Split a single-line conversation dump on speaker-name boundaries."""
+    matches = list(_INLINE_SPEAKER_RE.finditer(line))
+    if len(matches) < 2:
+        return [line]
+    segments = []
+    for i, m in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(line)
+        segments.append(line[m.start():end].strip())
+    return segments
+
+
 def _parse_turns(lines: list) -> list:
     turns = []
     for line in lines:
@@ -74,12 +97,15 @@ def _parse_turns(lines: list) -> list:
         line = ' '.join(line.split())
         if not line:
             continue
-        if ":" in line:
-            speaker, _, text = line.partition(":")
-            speaker = speaker.strip()
-            text = text.strip()
-            if speaker and text:
-                turns.append({"speaker": speaker, "text": text})
+        # Detect single-line dump (multiple speaker prefixes on one line)
+        segments = _split_inline_turns(line)
+        for seg in segments:
+            if ":" in seg:
+                speaker, _, text = seg.partition(":")
+                speaker = speaker.strip()
+                text = text.strip()
+                if speaker and text:
+                    turns.append({"speaker": speaker, "text": text})
     return turns
 
 

--- a/_NewDomains/language-german/parse_transcript.py
+++ b/_NewDomains/language-german/parse_transcript.py
@@ -70,7 +70,7 @@ def _parse_header(lines: list) -> dict:
 # Speaker names are 1-3 words, each word starts with a capital letter,
 # optionally prefixed with a title abbreviation ending in a period (e.g. Dr.).
 _INLINE_SPEAKER_RE = re.compile(
-    r'(?:^|(?<=\s))'
+    r'(?:^|(?<=[\s.?!]))'
     r'(?:(?:Dr|Frau|Herr|Prof)\.\s+)?'
     r'(?:[A-ZÄÖÜ][a-zäöüß]+(?:\s+[A-ZÄÖÜ][a-zäöüß]+)?)'
     r':'

--- a/_NewDomains/language-german/parse_transcript.py
+++ b/_NewDomains/language-german/parse_transcript.py
@@ -47,7 +47,9 @@ def _parse_header(lines: list) -> dict:
 def _parse_turns(lines: list) -> list:
     turns = []
     for line in lines:
-        line = line.strip()
+        # Normalize em-dash and en-dash to hyphen; collapse Unicode whitespace
+        line = line.replace('\u2014', '-').replace('\u2013', '-')
+        line = ' '.join(line.split())
         if not line:
             continue
         if ":" in line:
@@ -67,7 +69,7 @@ def _load_domain_defaults(sessions_dir: Path) -> dict:
 
 
 def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
-    trigger = START_TRIGGER if START_TRIGGER in raw_text else (START_TRIGGER_ALT if START_TRIGGER_ALT in raw_text.upper() else None)
+    trigger = START_TRIGGER if START_TRIGGER in raw_text else (START_TRIGGER_ALT if START_TRIGGER_ALT in raw_text else None)
     if trigger:
         start = raw_text.upper().index(trigger.upper()) + len(trigger)
         end_pos = raw_text.upper().find(END_TRIGGER, start)
@@ -78,8 +80,25 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
         body = raw_text.strip()
 
     sections = body.split("\n\n", 1)
-    header_lines = sections[0].strip().splitlines()
-    turn_lines = sections[1].strip().splitlines() if len(sections) > 1 else []
+    if len(sections) == 2:
+        header_lines = sections[0].strip().splitlines()
+        turn_lines = sections[1].strip().splitlines()
+    else:
+        # No blank line separator (common in iPhone/Grok formatting) —
+        # split by detecting known header fields vs. speaker turns
+        header_lines = []
+        turn_lines = []
+        past_header = False
+        for line in body.splitlines():
+            if not line.strip():
+                continue
+            if not past_header and ":" in line:
+                key = line.partition(":")[0].strip().lower()
+                if key in HEADER_FIELDS:
+                    header_lines.append(line)
+                    continue
+            past_header = True
+            turn_lines.append(line)
 
     header = _parse_header(header_lines)
     if not header:
@@ -106,6 +125,9 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
     session_id = _next_session_id(date_str, sessions_dir)
 
     turns = _parse_turns(turn_lines)
+
+    if not turns and body:
+        print("⚠️  WARNING: raw_transcript is empty after parsing non-empty body. Check transcript format.", file=sys.stderr)
 
     session = {
         "session_id": session_id,

--- a/_NewDomains/language-german/parse_transcript.py
+++ b/_NewDomains/language-german/parse_transcript.py
@@ -176,6 +176,11 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
     else:
         body = raw_text.strip()
 
+    # Fix missing newline when a header value runs directly into the conversation body,
+    # e.g. "Mode: voiceDr. Huber: Guten Tag!" → "Mode: voice\nDr. Huber: Guten Tag!"
+    body = re.sub(r'(?i)(Mode:\s*(?:voice|writing))([A-ZÄÖÜ])', r'\1\n\2', body)
+    body = re.sub(r'(?i)(Duration:\s*\d+)([A-ZÄÖÜ])', r'\1\n\2', body)
+
     sections = body.split("\n\n", 1)
     if len(sections) == 2:
         header_lines = sections[0].strip().splitlines()

--- a/_NewDomains/language-german/parse_transcript.py
+++ b/_NewDomains/language-german/parse_transcript.py
@@ -140,7 +140,10 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
         date_str, persona, scenario, dur_str, mode = key_match.groups()
         persona = persona.strip()
         scenario = scenario.strip()
-        mode = mode.strip().lower()
+        raw_mode = mode.strip().lower()
+        mode = raw_mode if raw_mode in {"voice", "writing"} else "writing"
+        if raw_mode not in {"voice", "writing"}:
+            print(f"⚠️  Unrecognised mode value '{raw_mode}' — defaulting to 'writing'")
         duration = int(dur_str)
         # Turn lines are everything except the key line
         turn_lines = [l for l in raw_text.splitlines() if not l.startswith("##")]
@@ -176,10 +179,16 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
     else:
         body = raw_text.strip()
 
-    # Fix missing newline when a header value runs directly into the conversation body,
-    # e.g. "Mode: voiceDr. Huber: Guten Tag!" → "Mode: voice\nDr. Huber: Guten Tag!"
-    body = re.sub(r'(?i)(Mode:\s*(?:voice|writing))([A-ZÄÖÜ])', r'\1\n\2', body)
-    body = re.sub(r'(?i)(Duration:\s*\d+)([A-ZÄÖÜ])', r'\1\n\2', body)
+    # Fix missing newline when a scalar header value runs directly into the conversation.
+    # Only applied to fields whose values never contain uppercase letters themselves:
+    #   Mode:     one word  (voice / writing / anything else)
+    #   Duration: digits
+    #   Date:     ISO date
+    # Persona/Scenario are skipped — their values are mixed-case names.
+    # (?i) makes [A-ZÄÖÜ] case-insensitive too, so use explicit case for the field key.
+    body = re.sub(r'([Mm]ode:\s*\w+)([A-ZÄÖÜ])', r'\1\n\2', body)
+    body = re.sub(r'([Dd]uration:\s*\d+)([A-ZÄÖÜ])', r'\1\n\2', body)
+    body = re.sub(r'([Dd]ate:\s*\d{4}-\d{2}-\d{2})([A-ZÄÖÜ])', r'\1\n\2', body)
 
     sections = body.split("\n\n", 1)
     if len(sections) == 2:
@@ -216,10 +225,13 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
     date_str = header.get("date", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
     persona = header.get("persona", "Unknown")
     scenario = header.get("scenario", "unknown")
-    mode = header.get("mode", "voice").lower()
-
-    # Mode detection from content — fuzzy override when header didn't set it
-    if mode == "voice" and "mode: writing" in raw_text.lower():
+    _VALID_MODES = {"voice", "writing"}
+    raw_mode = header.get("mode", "").strip().lower()
+    if raw_mode in _VALID_MODES:
+        mode = raw_mode
+    else:
+        if raw_mode:
+            print(f"⚠️  Unrecognised mode value '{raw_mode}' — defaulting to 'writing'")
         mode = "writing"
 
     if "duration" in header:

--- a/_NewDomains/language-german/parse_transcript.py
+++ b/_NewDomains/language-german/parse_transcript.py
@@ -23,6 +23,12 @@ END_TRIGGER = "---END---"
 END_TRIGGER_ALT = "\u2014END\u2014"
 HEADER_FIELDS = {"date", "persona", "scenario", "duration", "mode", "drill", "drill-session"}
 
+# Format 3: ##YYYY-MM-DD|persona|scenario|duration|mode
+_KEY_LINE_RE = re.compile(
+    r'^##(\d{4}-\d{2}-\d{2})\|([^|]+)\|([^|]+)\|(\d+)\|(\w+)$',
+    re.MULTILINE,
+)
+
 
 def _next_session_id(date_str: str, sessions_dir: Path) -> str:
     existing = sorted(sessions_dir.glob(f"{date_str}_*.json"))
@@ -84,7 +90,56 @@ def _load_domain_defaults(sessions_dir: Path) -> dict:
     return {}
 
 
+def _load_lesson_defaults(sessions_dir: Path) -> dict:
+    """Infer persona/scenario from most recent lesson file; fall back to domain.json."""
+    domain = _load_domain_defaults(sessions_dir)
+    defaults = {
+        "persona": domain.get("active_persona", "Unknown"),
+        "scenario": "unknown",
+    }
+    lessons_dir = sessions_dir.parent / "lessons"
+    if lessons_dir.exists():
+        lesson_files = sorted(lessons_dir.glob("*_lesson.json"))
+        if lesson_files:
+            lesson = json.loads(lesson_files[-1].read_text(encoding="utf-8"))
+            defaults["persona"] = lesson.get("persona", defaults["persona"])
+            defaults["scenario"] = lesson.get("scenario", defaults["scenario"])
+    return defaults
+
+
 def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
+    # --- Format 3: ##YYYY-MM-DD|persona|scenario|duration|mode key line ---
+    key_match = _KEY_LINE_RE.search(raw_text)
+    if key_match:
+        date_str, persona, scenario, dur_str, mode = key_match.groups()
+        persona = persona.strip()
+        scenario = scenario.strip()
+        mode = mode.strip().lower()
+        duration = int(dur_str)
+        # Turn lines are everything except the key line
+        turn_lines = [l for l in raw_text.splitlines() if not l.startswith("##")]
+        turns = _parse_turns(turn_lines)
+        if len(turns) < 2:
+            raise ValueError(
+                "⚠️ Couldn't parse a clear conversation (fewer than 2 turns found). "
+                "Paste again or upload the file directly — session not saved."
+            )
+        session_id = _next_session_id(date_str, sessions_dir)
+        session = {
+            "session_id": session_id, "date": date_str, "persona": persona,
+            "scenario": scenario, "duration_estimate_min": duration, "mode": mode,
+            "source": "manual", "raw_transcript": turns,
+            "reviewer_output": None, "anki_generated": False,
+            "next_lesson_generated": False, "drill_mode": False,
+            "drill_session": 0, "drill_total": 0,
+        }
+        out_path = sessions_dir / f"{session_id}.json"
+        out_path.write_text(json.dumps(session, indent=2, ensure_ascii=False))
+        print(f"✅ Session saved: {out_path}")
+        print(f"   Persona: {persona} | Scenario: {scenario} | Turns: {len(turns)}")
+        return out_path
+
+    # --- Formats 1 & 2: ---SESSION--- / —SESSION— delimited ---
     trigger = START_TRIGGER if START_TRIGGER in raw_text else (START_TRIGGER_ALT if START_TRIGGER_ALT in raw_text else None)
     if trigger:
         start = raw_text.upper().index(trigger.upper()) + len(trigger)
@@ -118,20 +173,24 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
 
     header = _parse_header(header_lines)
     if not header:
-        # No header found — all lines are turns; fall back to domain.json defaults
+        # No header found — fuzzy path: infer metadata from latest lesson file
         turn_lines = header_lines + turn_lines
-        domain_cfg = _load_domain_defaults(sessions_dir)
+        lesson_defaults = _load_lesson_defaults(sessions_dir)
         header = {
             "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
-            "persona": domain_cfg.get("active_persona", "Unknown"),
-            "scenario": "unknown",
-            "duration": "0",
+            "persona": lesson_defaults["persona"],
+            "scenario": lesson_defaults["scenario"],
         }
 
     date_str = header.get("date", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
     persona = header.get("persona", "Unknown")
     scenario = header.get("scenario", "unknown")
     mode = header.get("mode", "voice").lower()
+
+    # Mode detection from content — fuzzy override when header didn't set it
+    if mode == "voice" and "mode: writing" in raw_text.lower():
+        mode = "writing"
+
     if "duration" in header:
         m = re.search(r'\d+', header["duration"])
         duration = int(m.group()) if m else None
@@ -156,8 +215,15 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
 
     turns = _parse_turns(turn_lines)
 
-    if not turns and body:
-        print("⚠️  WARNING: raw_transcript is empty after parsing non-empty body. Check transcript format.", file=sys.stderr)
+    # Estimate duration from turn count if not provided (≈ 0.5 min per turn)
+    if duration is None:
+        duration = max(1, len(turns) // 2)
+
+    if len(turns) < 2:
+        raise ValueError(
+            "⚠️ Couldn't parse a clear conversation (fewer than 2 turns found). "
+            "Paste again or upload the file directly — session not saved."
+        )
 
     session = {
         "session_id": session_id,
@@ -200,7 +266,11 @@ def main():
     else:
         raw = Path(args.input).read_text(encoding="utf-8")
 
-    parse_transcript(raw, sessions_dir)
+    try:
+        parse_transcript(raw, sessions_dir)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/_NewDomains/language-german/parse_transcript.py
+++ b/_NewDomains/language-german/parse_transcript.py
@@ -21,7 +21,7 @@ START_TRIGGER = "---SESSION---"
 START_TRIGGER_ALT = "\u2014SESSION\u2014"  # iPhone auto-corrects --- to em-dash
 END_TRIGGER = "---END---"
 END_TRIGGER_ALT = "\u2014END\u2014"
-HEADER_FIELDS = {"date", "persona", "scenario", "duration", "mode"}
+HEADER_FIELDS = {"date", "persona", "scenario", "duration", "mode", "drill", "drill-session"}
 
 
 def _next_session_id(date_str: str, sessions_dir: Path) -> str:
@@ -122,6 +122,20 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
     else:
         duration = None
 
+    # Drill mode fields
+    drill_mode = header.get("drill", "").lower() == "true"
+    drill_session = 0
+    drill_total = 0
+    raw_ds = header.get("drill-session", "")  # e.g. "2 of 3"
+    if raw_ds:
+        parts = raw_ds.split("of")
+        if len(parts) == 2:
+            try:
+                drill_session = int(parts[0].strip())
+                drill_total   = int(parts[1].strip())
+            except ValueError:
+                pass
+
     session_id = _next_session_id(date_str, sessions_dir)
 
     turns = _parse_turns(turn_lines)
@@ -141,6 +155,9 @@ def parse_transcript(raw_text: str, sessions_dir: Path) -> Path:
         "reviewer_output": None,
         "anki_generated": False,
         "next_lesson_generated": False,
+        "drill_mode": drill_mode,
+        "drill_session": drill_session,
+        "drill_total": drill_total,
     }
 
     out_path = sessions_dir / f"{session_id}.json"

--- a/_NewDomains/language-german/parse_transcript.py
+++ b/_NewDomains/language-german/parse_transcript.py
@@ -34,8 +34,24 @@ def _next_session_id(date_str: str, sessions_dir: Path) -> str:
 
 
 def _parse_header(lines: list) -> dict:
-    fields = {}
+    # Expand lines that contain multiple fields inline (e.g. Grok single-line format:
+    # "Date: 2026-04-26 Persona: Klaus Scenario: ..." all on one line)
+    field_re = re.compile(
+        r'\b(' + '|'.join(re.escape(f) for f in HEADER_FIELDS) + r')\s*:',
+        re.IGNORECASE,
+    )
+    expanded = []
     for line in lines:
+        matches = list(field_re.finditer(line))
+        if len(matches) <= 1:
+            expanded.append(line)
+        else:
+            for i, m in enumerate(matches):
+                end = matches[i + 1].start() if i + 1 < len(matches) else len(line)
+                expanded.append(line[m.start():end].strip())
+
+    fields = {}
+    for line in expanded:
         if ":" in line:
             key, _, val = line.partition(":")
             key = key.strip().lower()

--- a/_NewDomains/language-german/reviewer.py
+++ b/_NewDomains/language-german/reviewer.py
@@ -384,13 +384,23 @@ def main():
     print(f"   Vocabulary highlights: {len(reviewer_output.get('vocabulary_highlights', []))}")
 
     # Step 3: Anki CSV + lesson plan
-    print("[3/4] Generating Anki CSV and lesson plan...")
-    new_vocab_count = _generate_anki_csv(reviewer_output, session, anki_dir, progress)
-    _generate_lesson_plan(reviewer_output, session, domain_cfg, personas, progress, lessons_dir)
+    drill_mode    = session.get("drill_mode", False)
+    drill_session = session.get("drill_session", 0)
+    drill_total   = session.get("drill_total", 0)
+    is_final_drill = drill_mode and drill_total > 0 and drill_session >= drill_total
+
+    if drill_mode and not is_final_drill:
+        print(f"[3/4] Drill session {drill_session}/{drill_total} — generating Anki CSV, skipping lesson rotation...")
+        new_vocab_count = _generate_anki_csv(reviewer_output, session, anki_dir, progress)
+        print(f"⏭️  Drill session {drill_session}/{drill_total} — skipping lesson rotation")
+    else:
+        print("[3/4] Generating Anki CSV and lesson plan...")
+        new_vocab_count = _generate_anki_csv(reviewer_output, session, anki_dir, progress)
+        _generate_lesson_plan(reviewer_output, session, domain_cfg, personas, progress, lessons_dir)
 
     # Mark session complete and save domain config (lesson counter incremented)
     session["anki_generated"] = True
-    session["next_lesson_generated"] = True
+    session["next_lesson_generated"] = not drill_mode or is_final_drill
     session_path.write_text(json.dumps(session, indent=2, ensure_ascii=False))
     domain_cfg_path.write_text(json.dumps(domain_cfg, indent=2, ensure_ascii=False))
 

--- a/_NewDomains/language-german/reviewer.py
+++ b/_NewDomains/language-german/reviewer.py
@@ -135,8 +135,8 @@ def _parse_llm_response(text: str) -> tuple[dict, bool]:
             return json.loads(m.group(1)), True
         except json.JSONDecodeError:
             pass
-    print(f"⚠️  LLM response parse failed. Storing raw output for debugging.")
-    print(f"   Raw (first 300 chars): {text[:300]}")
+    print(f"⚠️  LLM response parse failed. Storing raw output for debugging.", file=sys.stderr)
+    print(f"   Raw (first 300 chars): {text[:300]}", file=sys.stderr)
     return _empty_reviewer_output(), False
 
 
@@ -262,7 +262,7 @@ def _generate_lesson_plan(reviewer_output: dict, session: dict, domain_cfg: dict
         "lesson_date": next_date,
         "lesson_number": lesson_number + 1,
         "persona": next_persona["name"],
-        "persona_role": next_persona["role"],
+        "persona_role": next_persona["role"],  # from personas.json, never from reviewer_output
         "scenario": next_scenario,
         "warm_up": f"Review top error from last session: {top_error.replace('_', ' ')}.",
         "focus": reviewer_output.get("next_focus", ""),

--- a/_NewDomains/language-german/reviewer.py
+++ b/_NewDomains/language-german/reviewer.py
@@ -103,7 +103,7 @@ def _call_claude(session: dict, model: str) -> str:
     client = _get_anthropic_client()
     response = client.messages.create(
         model=model,
-        max_tokens=2048,
+        max_tokens=4096,
         system=SYSTEM_PROMPT,
         messages=[{"role": "user", "content": _build_user_prompt(session)}],
     )
@@ -123,13 +123,23 @@ def _empty_reviewer_output() -> dict:
     }
 
 
+def _strip_llm_fences(text: str) -> str:
+    """Strip markdown code fences (```json ... ``` or ``` ... ```) from LLM output."""
+    raw = text.strip()
+    if raw.startswith("```"):
+        raw = re.sub(r'^```[a-z]*\n?', '', raw)
+        raw = re.sub(r'\n?```$', '', raw)
+    return raw.strip()
+
+
 def _parse_llm_response(text: str) -> tuple[dict, bool]:
     """Return (parsed_dict, success). On failure returns fallback struct."""
     try:
-        return json.loads(text.strip()), True
+        return json.loads(_strip_llm_fences(text)), True
     except json.JSONDecodeError:
         pass
-    m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    # Greedy match — .*? would stop at first } and miss nested structures
+    m = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
     if m:
         try:
             return json.loads(m.group(1)), True

--- a/_NewDomains/language-german/run_tests.py
+++ b/_NewDomains/language-german/run_tests.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+run_tests.py — Acceptance tests for the German language pipeline.
+
+Usage:
+  python run_tests.py              # run all tests
+  python run_tests.py --test 9     # run one test by number
+"""
+import argparse
+import json
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+PIPELINE_ROOT = Path(__file__).parent
+GERMAN_BASE = PIPELINE_ROOT / "language" / "german"
+FIXTURES = PIPELINE_ROOT / "test_fixtures"
+
+sys.path.insert(0, str(PIPELINE_ROOT))
+
+PASS = "PASS"
+FAIL = "FAIL"
+results = []
+
+
+def report(n: int, label: str, passed: bool, detail: str = ""):
+    status = PASS if passed else FAIL
+    suffix = f" — {detail}" if detail else ""
+    print(f"Test {n:2d} — {label}: {status}{suffix}")
+    results.append((n, label, passed))
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — inline header parsing (Grok single-line format)
+# ---------------------------------------------------------------------------
+
+def test_9():
+    from parse_transcript import parse_transcript
+
+    fixture = FIXTURES / "sample_transcript_inline_header.txt"
+    raw = fixture.read_text(encoding="utf-8")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        sessions_dir = Path(tmp) / "sessions"
+        sessions_dir.mkdir()
+        # Provide a minimal domain.json so fallback path doesn't fire
+        cfg_dir = Path(tmp) / "config"
+        cfg_dir.mkdir()
+        (cfg_dir / "domain.json").write_text(
+            json.dumps({"active_persona": "Unknown", "current_lesson_number": 1})
+        )
+
+        out_path = parse_transcript(raw, sessions_dir)
+        session = json.loads(out_path.read_text(encoding="utf-8"))
+
+    checks = {
+        "persona == Klaus": session.get("persona") == "Klaus",
+        "scenario == restaurant_reservation": session.get("scenario") == "restaurant_reservation",
+        "mode == voice": session.get("mode") == "voice",
+        "duration == 8": session.get("duration_estimate_min") == 8,
+        "no Unknown persona": session.get("persona") != "Unknown",
+        "has turns": len(session.get("raw_transcript", [])) > 0,
+    }
+
+    all_pass = all(checks.values())
+    failed = [k for k, v in checks.items() if not v]
+    detail = ("all checks pass" if all_pass
+              else "failed: " + ", ".join(failed))
+    report(9, "inline header (Grok single-line format)", all_pass, detail)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+TESTS = {9: test_9}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test", type=int, help="Run a single test by number")
+    args = parser.parse_args()
+
+    to_run = [args.test] if args.test else sorted(TESTS)
+    for n in to_run:
+        if n not in TESTS:
+            print(f"Test {n}: not defined")
+            continue
+        TESTS[n]()
+
+    print()
+    passed = sum(1 for _, _, ok in results if ok)
+    total = len(results)
+    print(f"{passed}/{total} tests passed.")
+    sys.exit(0 if passed == total else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/_NewDomains/language-german/run_tests.py
+++ b/_NewDomains/language-german/run_tests.py
@@ -4,12 +4,22 @@ run_tests.py — Acceptance tests for the German language pipeline.
 
 Usage:
   python run_tests.py              # run all tests
-  python run_tests.py --test 9     # run one test by number
+  python run_tests.py --test 3     # run one test by number
+
+Tests:
+  1  parse_transcript: multi-line format → correct session JSON
+  2  parse_transcript: em-dash delimiter (iPhone autocorrect) → correct session JSON
+  3  get_german_session: UNIVERSAL_HEADER present in output
+  4  get_german_session: UNIVERSAL_FOOTER present in output
+  5  get_german_session: carry-forward strips session metadata noise
+  6  get_german_session --writing: header at top, Mode: writing in footer
+  7  persona files: all 8 have standard comment line
+  8  ORCHESTRATOR.md: exists and has all 7 command sections
+  9  parse_transcript: inline header (Grok single-line) → all fields, no Unknown
 """
 import argparse
 import json
-import re
-import shutil
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -20,62 +30,171 @@ FIXTURES = PIPELINE_ROOT / "test_fixtures"
 
 sys.path.insert(0, str(PIPELINE_ROOT))
 
-PASS = "PASS"
-FAIL = "FAIL"
 results = []
 
 
 def report(n: int, label: str, passed: bool, detail: str = ""):
-    status = PASS if passed else FAIL
+    status = "PASS" if passed else "FAIL"
     suffix = f" — {detail}" if detail else ""
     print(f"Test {n:2d} — {label}: {status}{suffix}")
     results.append((n, label, passed))
 
 
+def _parse_session(fixture_name: str) -> dict:
+    from parse_transcript import parse_transcript
+    raw = (FIXTURES / fixture_name).read_text(encoding="utf-8")
+    with tempfile.TemporaryDirectory() as tmp:
+        sessions_dir = Path(tmp) / "sessions"
+        sessions_dir.mkdir()
+        out = parse_transcript(raw, sessions_dir)
+        return json.loads(out.read_text(encoding="utf-8"))
+
+
+def _run_get_session(*extra_args) -> str:
+    result = subprocess.run(
+        [sys.executable, str(PIPELINE_ROOT / "get_german_session.py"),
+         "--base-dir", str(GERMAN_BASE), "--dry-run"] + list(extra_args),
+        capture_output=True, text=True,
+    )
+    return result.stdout
+
+
 # ---------------------------------------------------------------------------
-# Test 9 — inline header parsing (Grok single-line format)
+# Tests 1-2: parse_transcript formats
+# ---------------------------------------------------------------------------
+
+def test_1():
+    session = _parse_session("sample_transcript.txt")
+    checks = {
+        "persona == Frau Berger": session.get("persona") == "Frau Berger",
+        "scenario == bakery_order": session.get("scenario") == "bakery_order",
+        "has turns": len(session.get("raw_transcript", [])) > 0,
+        "no Unknown": session.get("persona") != "Unknown",
+    }
+    ok = all(checks.values())
+    report(1, "parse multi-line format", ok,
+           "all checks pass" if ok else "failed: " + ", ".join(k for k, v in checks.items() if not v))
+
+
+def test_2():
+    session = _parse_session("sample_transcript_emdash.txt")
+    checks = {
+        "persona == Stefan": session.get("persona") == "Stefan",
+        "has turns": len(session.get("raw_transcript", [])) > 0,
+        "no Unknown": session.get("persona") != "Unknown",
+    }
+    ok = all(checks.values())
+    report(2, "parse em-dash delimiter (iPhone format)", ok,
+           "all checks pass" if ok else "failed: " + ", ".join(k for k, v in checks.items() if not v))
+
+
+# ---------------------------------------------------------------------------
+# Tests 3-6: get_german_session.py output
+# ---------------------------------------------------------------------------
+
+def test_3():
+    out = _run_get_session()
+    ok = "SESSION INSTRUCTIONS — READ BEFORE STARTING" in out
+    report(3, "universal header present in session output", ok)
+
+
+def test_4():
+    out = _run_get_session()
+    ok = "HOW TO END THIS SESSION" in out and "---SESSION---" in out
+    report(4, "universal footer present in session output", ok)
+
+
+def test_5():
+    out = _run_get_session()
+    carry_lines = [l for l in out.splitlines() if l.startswith("Carry forward:")]
+    if not carry_lines:
+        report(5, "carry-forward has no session metadata noise", False, "Carry forward line not found")
+        return
+    carry_val = carry_lines[0]
+    noise = "Persona:" in carry_val or "Scenario:" in carry_val or "Duration:" in carry_val or "Mode:" in carry_val
+    report(5, "carry-forward has no session metadata noise", not noise,
+           carry_val if noise else "clean")
+
+
+def test_6():
+    out = _run_get_session("--writing")
+    first_line = out.strip().splitlines()[0] if out.strip() else ""
+    header_at_top = "WRITING SESSION" in first_line
+    mode_writing = "Mode: writing" in out
+    mode_voice = "Mode: voice" in out
+    ok = header_at_top and mode_writing and not mode_voice
+    checks = {
+        "⌨️ WRITING SESSION at top": header_at_top,
+        "Mode: writing in footer": mode_writing,
+        "no Mode: voice": not mode_voice,
+    }
+    report(6, "--writing: header at top, Mode: writing", ok,
+           "all checks pass" if ok else "failed: " + ", ".join(k for k, v in checks.items() if not v))
+
+
+# ---------------------------------------------------------------------------
+# Test 7: persona files authoring standard
+# ---------------------------------------------------------------------------
+
+def test_7():
+    prompts_dir = GERMAN_BASE / "config" / "prompts"
+    persona_files = sorted(prompts_dir.glob("*.txt"))
+    STANDARD_COMMENT = "# Target: under 3500 chars | Vocabulary: 6-8 items max | Persona: 3-4 sentences max"
+    missing = [f.name for f in persona_files if STANDARD_COMMENT not in f.read_text(encoding="utf-8")]
+    ok = len(missing) == 0
+    report(7, f"all {len(persona_files)} persona files have standard comment", ok,
+           "all present" if ok else "missing in: " + ", ".join(missing))
+
+
+# ---------------------------------------------------------------------------
+# Test 8: ORCHESTRATOR.md
+# ---------------------------------------------------------------------------
+
+def test_8():
+    orc = PIPELINE_ROOT / "ORCHESTRATOR.md"
+    if not orc.exists():
+        report(8, "ORCHESTRATOR.md exists with 7 command sections", False, "file missing")
+        return
+    content = orc.read_text(encoding="utf-8")
+    expected = ["Session Pull", "Writing Session", "Drill Mode", "Status",
+                "Anki Import", "Watcher Start", "Watcher Stop"]
+    missing = [s for s in expected if s not in content]
+    ok = len(missing) == 0
+    report(8, "ORCHESTRATOR.md exists with 7 command sections", ok,
+           "all sections present" if ok else "missing: " + ", ".join(missing))
+
+
+# ---------------------------------------------------------------------------
+# Test 9: inline header (Grok single-line format)
 # ---------------------------------------------------------------------------
 
 def test_9():
     from parse_transcript import parse_transcript
-
-    fixture = FIXTURES / "sample_transcript_inline_header.txt"
-    raw = fixture.read_text(encoding="utf-8")
-
+    raw = (FIXTURES / "sample_transcript_inline_header.txt").read_text(encoding="utf-8")
     with tempfile.TemporaryDirectory() as tmp:
         sessions_dir = Path(tmp) / "sessions"
         sessions_dir.mkdir()
-        # Provide a minimal domain.json so fallback path doesn't fire
-        cfg_dir = Path(tmp) / "config"
-        cfg_dir.mkdir()
-        (cfg_dir / "domain.json").write_text(
-            json.dumps({"active_persona": "Unknown", "current_lesson_number": 1})
-        )
-
         out_path = parse_transcript(raw, sessions_dir)
         session = json.loads(out_path.read_text(encoding="utf-8"))
-
     checks = {
         "persona == Klaus": session.get("persona") == "Klaus",
         "scenario == restaurant_reservation": session.get("scenario") == "restaurant_reservation",
         "mode == voice": session.get("mode") == "voice",
         "duration == 8": session.get("duration_estimate_min") == 8,
-        "no Unknown persona": session.get("persona") != "Unknown",
+        "no Unknown": session.get("persona") != "Unknown",
         "has turns": len(session.get("raw_transcript", [])) > 0,
     }
-
-    all_pass = all(checks.values())
-    failed = [k for k, v in checks.items() if not v]
-    detail = ("all checks pass" if all_pass
-              else "failed: " + ", ".join(failed))
-    report(9, "inline header (Grok single-line format)", all_pass, detail)
+    ok = all(checks.values())
+    report(9, "inline header (Grok single-line format)", ok,
+           "all checks pass" if ok else "failed: " + ", ".join(k for k, v in checks.items() if not v))
 
 
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
-TESTS = {9: test_9}
+TESTS = {1: test_1, 2: test_2, 3: test_3, 4: test_4, 5: test_5,
+         6: test_6, 7: test_7, 8: test_8, 9: test_9}
 
 
 def main():

--- a/_NewDomains/language-german/test_fixtures/sample_transcript_emdash.txt
+++ b/_NewDomains/language-german/test_fixtures/sample_transcript_emdash.txt
@@ -1,0 +1,17 @@
+—SESSION—
+Date: 2026-04-24
+Persona: Stefan
+Scenario: U-Bahn
+Duration: 12
+Stefan: Servus, Grüß Gott! Fahrschein bitte. Hast du einen gültigen Ticket?
+Robert: Nein, ich habe nicht.
+Stefan: Kein Ticket? Dann brauchst du einen. Wohin willst du eigentlich? Zum Prater oder zum Stephansdom?
+Robert: Was ist der Unterschied?
+Stefan: Zum Prater nimmst du die U1 Richtung Leopoldau, einfach einsteigen, keine Umsteigung. Zum Stephansdom gehst du direkt raus, der ist gleich oben.
+Robert: Ich möchte gern spazieren. Wo ist besser?
+Stefan: Der Prater ist viel besser zum Spazieren, da hast du den großen Park und den Wurstelprater mit dem Riesenrad. Nimm einfach die U1, zwei Stationen.
+Robert: Genau, ich nehme mich.
+Stefan: Nimmst die U1 Richtung Leopoldau, zwei Stationen, dann bist du schon im Prater. Servus und viel Spaß!
+Robert: Danke dir.
+Stefan: Gerne. Viel Spaß beim Spazieren im Prater! Servus.
+—END—

--- a/_NewDomains/language-german/test_fixtures/sample_transcript_inline_header.txt
+++ b/_NewDomains/language-german/test_fixtures/sample_transcript_inline_header.txt
@@ -1,0 +1,13 @@
+---SESSION---
+Date: 2026-04-26 Persona: Klaus Scenario: restaurant_reservation Duration: 8 Mode: voice
+
+Klaus: Guten Abend, hier spricht Klaus vom Restaurant Zum Goldenen Hirsch. Wie kann ich Ihnen helfen?
+Robert: Ich möchte eine Reservierung machen.
+Klaus: Selbstverständlich. Für wann und für wie viele Personen?
+Robert: Für zwei Personen, morgen Abend um sieben Uhr.
+Klaus: Sehr gerne. Darf ich Ihren Namen bitte?
+Robert: Mein Name ist Robert.
+Klaus: Perfekt, Herr Robert. Ich habe Sie für morgen Abend um 19 Uhr für zwei Personen eingetragen. Vielen Dank!
+Robert: Danke schön. Auf Wiederhören.
+Klaus: Auf Wiederhören!
+---END---

--- a/_NewDomains/language-german/watch_transcripts.py
+++ b/_NewDomains/language-german/watch_transcripts.py
@@ -83,6 +83,14 @@ def _tg_enabled(key: str) -> bool:
 
 # ─── File stability ───────────────────────────────────────────────────────────
 
+def _is_valid_utf8(path: Path) -> bool:
+    try:
+        path.read_text(encoding="utf-8")
+        return True
+    except (UnicodeDecodeError, OSError):
+        return False
+
+
 def _is_stable(path: Path, checks: int = 3, interval: float = 1.0) -> bool:
     sizes = []
     for _ in range(checks):
@@ -118,7 +126,6 @@ def _process(path: Path) -> None:
     )
     if rc != 0:
         _fail(name, "parse_transcript.py", err or out)
-        return
     logging.info(f"  parse OK: {out.strip()}")
 
     # Step 2 — review
@@ -128,7 +135,6 @@ def _process(path: Path) -> None:
     )
     if rc != 0:
         _fail(name, "reviewer.py", err or out)
-        return
     logging.info(f"  review OK")
 
     # Step 3 — Anki import (graceful degradation)
@@ -164,7 +170,6 @@ def _process(path: Path) -> None:
         )
         if rc != 0:
             _fail(name, "get_german_session.py", err or out)
-            return
         logging.info(f"  session prompt written to Dropbox + sent to Telegram")
     else:
         logging.info(f"  drill session {drill_session}/{drill_total} — skipping prompt rotation")
@@ -186,6 +191,7 @@ def _fail(name: str, step: str, error: str) -> None:
     logging.error(msg)
     if _tg_enabled("send_telegram_on_error"):
         _tg_send(msg)
+    raise RuntimeError(msg)
 
 # ─── Main loop ────────────────────────────────────────────────────────────────
 
@@ -203,12 +209,22 @@ def main() -> None:
         _tg_send(f"🟢 German watcher active — polling ~/Dropbox/German_Sessions every {POLL_INTERVAL}s")
 
     seen: set[str] = set()
+    failed: set[str] = set()
 
     while True:
         try:
+            all_files = [f for f in os.listdir(INBOX) if Path(f).suffix in EXTENSIONS]
+            for f in all_files:
+                if f.startswith("~$") and f not in seen:
+                    logging.info(f"Ignoring temp file: {f}")
+                    seen.add(f)
+                elif f in failed:
+                    logging.info(f"⚠️ Skipping previously failed file: {f}")
             candidates = [
-                INBOX / f for f in os.listdir(INBOX)
-                if Path(f).suffix in EXTENSIONS and f not in seen
+                INBOX / f for f in all_files
+                if not f.startswith("~$")
+                and f not in seen
+                and f not in failed
             ]
             for path in sorted(candidates):
                 seen.add(path.name)
@@ -216,10 +232,17 @@ def main() -> None:
                     logging.info(f"Skipping unstable file: {path.name}")
                     seen.discard(path.name)  # retry next poll
                     continue
+                if not _is_valid_utf8(path):
+                    msg = f"⚠️ File {path.name} has encoding issues — re-save as UTF-8"
+                    logging.warning(msg)
+                    _tg_send(msg)
+                    failed.add(path.name)
+                    continue
                 try:
                     _process(path)
                 except Exception as e:
                     _fail(path.name, "unexpected error", str(e))
+                    failed.add(path.name)
         except Exception as e:
             logging.error(f"Poll loop error: {e}")
 

--- a/_NewDomains/language-german/watch_transcripts.py
+++ b/_NewDomains/language-german/watch_transcripts.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+watch_transcripts.py — Poll Dropbox inbox for German session transcripts and run pipeline.
+
+Usage:
+  cd _NewDomains/language-german
+  python3 watch_transcripts.py
+
+Stop:
+  pkill -f watch_transcripts
+
+Check running:
+  pgrep -fl watch_transcripts
+"""
+import json
+import logging
+import os
+import random
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+HERE = Path(__file__).parent
+PROJECT_ROOT = HERE.parent.parent
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+def _load_config() -> dict:
+    cfg_path = HERE / "language/german/config/sync_config.json"
+    return json.loads(cfg_path.read_text(encoding="utf-8"))
+
+CFG = _load_config()
+
+BASE_PATH      = Path(CFG["base_path"]).expanduser()
+INBOX          = BASE_PATH / CFG["transcripts_inbox_dir"]
+PROCESSED      = BASE_PATH / CFG["transcripts_processed_dir"]
+PROMPTS        = BASE_PATH / CFG["prompts_dir"]
+LOGS           = BASE_PATH / "logs"
+LOG_FILE       = LOGS / "watcher.log"
+POLL_INTERVAL  = CFG["poll_interval_seconds"]
+EXTENSIONS     = set(CFG["supported_extensions"])
+PIPELINE_BASE  = CFG["pipeline_base_dir"]  # relative to project root
+VENV_PYTHON    = PROJECT_ROOT / "venv/bin/python3"
+
+# ─── Logging ─────────────────────────────────────────────────────────────────
+
+def _setup_logging():
+    LOGS.mkdir(parents=True, exist_ok=True)
+    handler = logging.handlers.RotatingFileHandler(
+        LOG_FILE, maxBytes=1_000_000, backupCount=2, encoding="utf-8"
+    )
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        handlers=[handler, logging.StreamHandler(sys.stdout)],
+    )
+
+import logging.handlers  # import here so the function above can reference it
+
+# ─── Telegram ────────────────────────────────────────────────────────────────
+
+def _tg_send(text: str) -> None:
+    try:
+        import keyring, requests as req
+        token   = keyring.get_password("telegram", "polling_bot_token")
+        chat_id = keyring.get_password("telegram", "chat_id")
+        if not token or not chat_id:
+            logging.warning("Telegram credentials missing — skipping notification")
+            return
+        req.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            json={"chat_id": chat_id, "text": text, "disable_web_page_preview": True},
+            timeout=15,
+        )
+    except Exception as e:
+        logging.warning(f"Telegram send failed: {e}")
+
+def _tg_enabled(key: str) -> bool:
+    return CFG.get(key, True)
+
+# ─── File stability ───────────────────────────────────────────────────────────
+
+def _is_stable(path: Path, checks: int = 3, interval: float = 1.0) -> bool:
+    sizes = []
+    for _ in range(checks):
+        try:
+            sizes.append(path.stat().st_size)
+        except FileNotFoundError:
+            return False
+        time.sleep(interval)
+    return len(set(sizes)) == 1 and sizes[0] > 0
+
+# ─── Pipeline ─────────────────────────────────────────────────────────────────
+
+def _run(cmd: list, cwd: Path) -> tuple[str, str, int]:
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=str(cwd)
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def _process(path: Path) -> None:
+    name = path.name
+    logging.info(f"Processing: {name}")
+    if _tg_enabled("send_telegram_on_start"):
+        _tg_send(f"📥 Transcript received — parsing {name}...")
+
+    cwd = HERE
+
+    # Step 1 — parse
+    out, err, rc = _run(
+        [str(VENV_PYTHON), "parse_transcript.py",
+         "--input", str(path), "--base-dir", "language/german/"],
+        cwd=cwd,
+    )
+    if rc != 0:
+        _fail(name, "parse_transcript.py", err or out)
+        return
+    logging.info(f"  parse OK: {out.strip()}")
+
+    # Step 2 — review
+    out, err, rc = _run(
+        [str(VENV_PYTHON), "reviewer.py", "--latest", "--base-dir", "language/german/"],
+        cwd=cwd,
+    )
+    if rc != 0:
+        _fail(name, "reviewer.py", err or out)
+        return
+    logging.info(f"  review OK")
+
+    # Step 3 — Anki import (graceful degradation)
+    out, err, rc = _run([str(VENV_PYTHON), "import_cards.py"], cwd=cwd)
+    if rc != 0:
+        logging.warning(f"  import_cards.py unavailable (AnkiConnect?): {err.strip()}")
+    else:
+        logging.info(f"  anki OK: {out.strip()}")
+
+    # Step 4 — check drill mode (read latest session JSON)
+    sessions_dir = HERE / "language/german/sessions"
+    session_files = sorted(sessions_dir.glob("*.json"))
+    drill_mode = False
+    drill_session = 0
+    drill_total = 1
+    if session_files:
+        try:
+            sess = json.loads(session_files[-1].read_text(encoding="utf-8"))
+            drill_mode    = sess.get("drill_mode", False)
+            drill_session = sess.get("drill_session", 0)
+            drill_total   = sess.get("drill_total", 1)
+        except Exception:
+            pass
+
+    is_final_drill = drill_mode and drill_session >= drill_total
+
+    # Step 5 — next session prompt (skip if mid-drill)
+    if not drill_mode or is_final_drill:
+        out, err, rc = _run(
+            [str(VENV_PYTHON), "get_german_session.py",
+             "--base-dir", "language/german/", "--dropbox", "--send"],
+            cwd=cwd,
+        )
+        if rc != 0:
+            _fail(name, "get_german_session.py", err or out)
+            return
+        logging.info(f"  session prompt written to Dropbox + sent to Telegram")
+    else:
+        logging.info(f"  drill session {drill_session}/{drill_total} — skipping prompt rotation")
+
+    # Step 6 — move to processed
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    dest = PROCESSED / f"{ts}_{name}"
+    shutil.move(str(path), str(dest))
+    logging.info(f"  moved to processed: {dest.name}")
+
+    if _tg_enabled("send_telegram_on_success") and (not drill_mode or is_final_drill):
+        _tg_send(f"✅ Pipeline complete. Next prompt in Dropbox.")
+    elif drill_mode and not is_final_drill:
+        _tg_send(f"✅ Drill session {drill_session}/{drill_total} processed. Keep going!")
+
+
+def _fail(name: str, step: str, error: str) -> None:
+    msg = f"❌ Pipeline failed at {step}: {name}\n{error[:400]}"
+    logging.error(msg)
+    if _tg_enabled("send_telegram_on_error"):
+        _tg_send(msg)
+
+# ─── Main loop ────────────────────────────────────────────────────────────────
+
+def _ensure_dirs() -> None:
+    for d in [INBOX, PROCESSED, PROMPTS, LOGS]:
+        d.mkdir(parents=True, exist_ok=True)
+
+
+def main() -> None:
+    _setup_logging()
+    _ensure_dirs()
+
+    logging.info("German watcher starting...")
+    if _tg_enabled("send_telegram_on_start"):
+        _tg_send(f"🟢 German watcher active — polling ~/Dropbox/German_Sessions every {POLL_INTERVAL}s")
+
+    seen: set[str] = set()
+
+    while True:
+        try:
+            candidates = [
+                INBOX / f for f in os.listdir(INBOX)
+                if Path(f).suffix in EXTENSIONS and f not in seen
+            ]
+            for path in sorted(candidates):
+                seen.add(path.name)
+                if not _is_stable(path):
+                    logging.info(f"Skipping unstable file: {path.name}")
+                    seen.discard(path.name)  # retry next poll
+                    continue
+                try:
+                    _process(path)
+                except Exception as e:
+                    _fail(path.name, "unexpected error", str(e))
+        except Exception as e:
+            logging.error(f"Poll loop error: {e}")
+
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/store_key.py
+++ b/scripts/store_key.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Store an API key in the macOS Keychain.
+
+Usage:
+  python3 scripts/store_key.py <service> <account>
+
+Examples:
+  python3 scripts/store_key.py openai api_key
+  python3 scripts/store_key.py anthropic api_key
+  python3 scripts/store_key.py xai api_key
+  python3 scripts/store_key.py telegram bot_token
+  python3 scripts/store_key.py telegram polling_bot_token
+"""
+import getpass
+import subprocess
+import sys
+
+if len(sys.argv) != 3:
+    print(__doc__)
+    sys.exit(1)
+
+service, account = sys.argv[1], sys.argv[2]
+key = getpass.getpass(f"Paste value for {service}/{account} (input hidden): ")
+
+result = subprocess.run(
+    ["security", "add-generic-password", "-s", service, "-a", account, "-w", key, "-U"],
+    capture_output=True, text=True,
+)
+
+if result.returncode == 0:
+    print(f"✅ Stored in Keychain: service='{service}', account='{account}'")
+else:
+    print(f"❌ Error: {result.stderr.strip()}")
+    sys.exit(1)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -569,6 +569,12 @@ GERMAN_BASE = BASE_DIR / "_NewDomains" / "language-german"
 GERMAN_DIR  = GERMAN_BASE / "language" / "german"
 VENV_PYTHON = BASE_DIR / "venv" / "bin" / "python3"
 
+_WRITING_RE = re.compile(
+    r"(writing session|written session|"
+    r"session.{0,20}writing|writing.{0,20}session|"
+    r"next.{0,20}german.{0,20}writing|german.{0,20}writing)",
+    re.I,
+)
 _SESSION_RE = re.compile(
     r"(pull today.?s german session|what.?s my german session|"
     r"give me today.?s german prompt|german session please|"
@@ -817,6 +823,8 @@ async def handle_text_message(update: Update, context: ContextTypes.DEFAULT_TYPE
         await _handle_german_command(update, text)
     elif _DRILL_RE.search(text):
         await _handle_german_command(update, "!german drill 3")
+    elif _WRITING_RE.search(text):
+        await _handle_german_command(update, "!german writing")
     elif _SESSION_RE.search(text):
         await _handle_german_command(update, "!german session")
     else:
@@ -854,6 +862,8 @@ async def handle_voice_polling(update: Update, context: ContextTypes.DEFAULT_TYP
         await _handle_german_command(update, text)
     elif _DRILL_RE.search(text):
         await _handle_german_command(update, "!german drill 3")
+    elif _WRITING_RE.search(text):
+        await _handle_german_command(update, "!german writing")
     elif _SESSION_RE.search(text):
         await _handle_german_command(update, "!german session")
     else:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -649,11 +649,38 @@ async def _handle_german_command(update: Update, text: str):
 
     elif cmd == "session":
         out, err, rc = _run(
-            [str(VENV_PYTHON), "get_german_session.py", "--base-dir", "language/german/", "--send"],
+            [str(VENV_PYTHON), "get_german_session.py",
+             "--base-dir", "language/german/", "--dropbox", "--send"],
             cwd=str(GERMAN_BASE)
         )
         if rc != 0:
             await update.message.reply_text(f"❌ get_german_session.py failed:\n{err[:400]}")
+
+    elif cmd == "drill":
+        # Usage: !german drill [persona] [scenario] [N]
+        # e.g.  !german drill Stefan ubahn 3
+        # N defaults to 3 if omitted
+        drill_parts = parts[2:]  # everything after "drill"
+        drill_n = 3
+        if drill_parts:
+            try:
+                drill_n = int(drill_parts[-1])
+                drill_parts = drill_parts[:-1]
+            except ValueError:
+                pass
+        out, err, rc = _run(
+            [str(VENV_PYTHON), "get_german_session.py",
+             "--base-dir", "language/german/",
+             "--drill", str(drill_n),
+             "--dropbox", "--send"],
+            cwd=str(GERMAN_BASE)
+        )
+        if rc != 0:
+            await update.message.reply_text(f"❌ get_german_session.py (drill) failed:\n{err[:400]}")
+        else:
+            await update.message.reply_text(
+                f"✅ {drill_n} drill prompts written to Dropbox. Session 1 sent to Telegram."
+            )
 
     elif cmd == "today":
         out, err, rc = _run(
@@ -709,6 +736,7 @@ async def _handle_german_command(update: Update, text: str):
         await update.message.reply_text(
             "German commands:\n"
             "  !german session\n"
+            "  !german drill [persona] [scenario] [N]\n"
             "  !german status\n"
             "  !german progress\n"
             "  !german today\n"
@@ -733,11 +761,19 @@ async def handle_text_message(update: Update, context: ContextTypes.DEFAULT_TYPE
         r"german session today|today.?s german session)",
         re.I,
     )
+    _DRILL_RE = re.compile(
+        r"(start german.{0,20}drill mode|drill.{0,30}german|german.{0,30}drill"
+        r"|drill (café|cafe|bakery|hotel|museum|pharmacy|restaurant|ubahn|u-bahn|transit|directions?)"
+        r"|\d+ drill sessions?)",
+        re.I,
+    )
 
     if text.startswith("---SESSION---") or text.lower().startswith("\u2014session\u2014"):
         await _handle_german_transcript(update, text)
     elif text.lower().startswith("!german"):
         await _handle_german_command(update, text)
+    elif _DRILL_RE.search(text):
+        await _handle_german_command(update, "!german drill 3")
     elif _SESSION_RE.search(text):
         await _handle_german_command(update, "!german session")
     else:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -612,6 +612,8 @@ async def _handle_german_transcript(update: Update, text: str):
         await update.message.reply_text(f"❌ status.py failed (exit {rc}):\n{err[:400]}")
         return
 
+    if not out or out.strip().startswith("{"):
+        out = "⚠️ Pipeline completed but status output was empty or unexpected.\nRun !german status to check."
     await update.message.reply_text(f"<pre>{escape(out)}</pre>", parse_mode="HTML")
 
 
@@ -715,7 +717,7 @@ async def handle_text_message(update: Update, context: ContextTypes.DEFAULT_TYPE
 
     text = update.message.text.strip()
 
-    if text.startswith("---SESSION---"):
+    if text.startswith("---SESSION---") or text.lower().startswith("\u2014session\u2014"):
         await _handle_german_transcript(update, text)
     elif text.lower().startswith("!german"):
         await _handle_german_command(update, text)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -782,17 +782,13 @@ async def _handle_german_command(update: Update, text: str):
     else:
         await update.message.reply_text(
             "German commands:\n"
-            "  !german session\n"
-            "  !german writing\n"
-            "  !german drill [persona] [scenario] [N]\n"
-            "  !german status\n"
-            "  !german progress\n"
-            "  !german today\n"
-            "  !german persona [name]\n"
-            "  !german watcher start\n"
-            "  !german watcher stop\n"
-            "  !german anki\n"
-            "  !german debug"
+            "  !german session       — get today's session prompt\n"
+            "  !german writing       — get today's writing session prompt\n"
+            "  !german drill [N]     — generate N drill sessions\n"
+            "  !german status        — current progress summary\n"
+            "  !german anki          — import Anki cards\n"
+            "  !german watcher start — start Dropbox transcript watcher\n"
+            "  !german watcher stop  — stop watcher"
         )
 
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -647,6 +647,14 @@ async def _handle_german_command(update: Update, text: str):
         ]
         await update.message.reply_text("\n".join(lines))
 
+    elif cmd == "session":
+        out, err, rc = _run(
+            [str(VENV_PYTHON), "get_german_session.py", "--base-dir", "language/german/", "--send"],
+            cwd=str(GERMAN_BASE)
+        )
+        if rc != 0:
+            await update.message.reply_text(f"❌ get_german_session.py failed:\n{err[:400]}")
+
     elif cmd == "today":
         out, err, rc = _run(
             [str(VENV_PYTHON), "reviewer.py", "--latest", "--base-dir", "language/german/"],
@@ -700,6 +708,7 @@ async def _handle_german_command(update: Update, text: str):
     else:
         await update.message.reply_text(
             "German commands:\n"
+            "  !german session\n"
             "  !german status\n"
             "  !german progress\n"
             "  !german today\n"
@@ -718,10 +727,19 @@ async def handle_text_message(update: Update, context: ContextTypes.DEFAULT_TYPE
 
     text = update.message.text.strip()
 
+    _SESSION_RE = re.compile(
+        r"(pull today.?s german session|what.?s my german session|"
+        r"give me today.?s german prompt|german session please|"
+        r"german session today|today.?s german session)",
+        re.I,
+    )
+
     if text.startswith("---SESSION---") or text.lower().startswith("\u2014session\u2014"):
         await _handle_german_transcript(update, text)
     elif text.lower().startswith("!german"):
         await _handle_german_command(update, text)
+    elif _SESSION_RE.search(text):
+        await _handle_german_command(update, "!german session")
     else:
         await update.message.reply_text(
             "Got it — I hear you. Send !german status to test the pipeline."

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -12,6 +12,7 @@ from html import escape
 import os
 import io
 import re
+import sys
 import json
 import threading
 import subprocess
@@ -734,7 +735,26 @@ def run_bot_mode():
     if not token:
         print("❌ No polling token found (keyring 'telegram/polling_bot_token' or TELEGRAM_POLLING_BOT_TOKEN)")
         return
-    
+
+    # Startup conflict check: fail fast if another process is already polling this token
+    try:
+        resp = requests.get(
+            f"https://api.telegram.org/bot{token}/getUpdates",
+            params={"timeout": 1},
+            timeout=5,
+        )
+        if resp.status_code == 409:
+            print(
+                "❌ FATAL: Another process is already polling this bot token.\n"
+                "Only one poller is allowed per token (see ARCHITECTURE.md).\n"
+                "Check for other running telegram_bot.py or OpenClaw processes.\n"
+                "Exiting.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    except requests.RequestException as e:
+        print(f"⚠️  Startup conflict check failed (network error): {e}", file=sys.stderr)
+
     print("🤖 Unified Telegram bot starting...")
     app = Application.builder().token(token).build()
     

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -569,6 +569,20 @@ GERMAN_BASE = BASE_DIR / "_NewDomains" / "language-german"
 GERMAN_DIR  = GERMAN_BASE / "language" / "german"
 VENV_PYTHON = BASE_DIR / "venv" / "bin" / "python3"
 
+_SESSION_RE = re.compile(
+    r"(pull today.?s german session|what.?s my german session|"
+    r"give me today.?s german prompt|german session please|"
+    r"german session today|today.?s german session|"
+    r"german session|next session|next lesson)",
+    re.I,
+)
+_DRILL_RE = re.compile(
+    r"(start german.{0,20}drill mode|drill.{0,30}german|german.{0,30}drill"
+    r"|drill (café|cafe|bakery|hotel|museum|pharmacy|restaurant|ubahn|u-bahn|transit|directions?)"
+    r"|\d+ drill sessions?)",
+    re.I,
+)
+
 
 def _run(cmd, **kwargs):
     """Run a subprocess, return (stdout, stderr, returncode)."""
@@ -797,19 +811,6 @@ async def handle_text_message(update: Update, context: ContextTypes.DEFAULT_TYPE
 
     text = update.message.text.strip()
 
-    _SESSION_RE = re.compile(
-        r"(pull today.?s german session|what.?s my german session|"
-        r"give me today.?s german prompt|german session please|"
-        r"german session today|today.?s german session)",
-        re.I,
-    )
-    _DRILL_RE = re.compile(
-        r"(start german.{0,20}drill mode|drill.{0,30}german|german.{0,30}drill"
-        r"|drill (café|cafe|bakery|hotel|museum|pharmacy|restaurant|ubahn|u-bahn|transit|directions?)"
-        r"|\d+ drill sessions?)",
-        re.I,
-    )
-
     if text.startswith("---SESSION---") or text.lower().startswith("\u2014session\u2014"):
         await _handle_german_transcript(update, text)
     elif text.lower().startswith("!german"):
@@ -822,6 +823,41 @@ async def handle_text_message(update: Update, context: ContextTypes.DEFAULT_TYPE
         await update.message.reply_text(
             "Got it — I hear you. Send !german status to test the pipeline."
         )
+
+
+async def handle_voice_polling(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle voice messages in polling mode: transcribe → echo → route."""
+    if not update.message or not update.message.voice:
+        return
+    if update.message.chat_id != ROBERT_CHAT_ID:
+        return
+
+    voice = update.message.voice
+    if voice.duration > 120:
+        await update.message.reply_text("⚠️ Voice note too long (>2 min). Ignored.")
+        return
+
+    try:
+        tg_file = await context.bot.get_file(voice.file_id)
+        audio_bytes = bytes(await tg_file.download_as_bytearray())
+        transcription = transcribe_voice(audio_bytes)
+    except Exception as e:
+        await update.message.reply_text(f"❌ Transcription failed: {e}")
+        return
+
+    await update.message.reply_text(f'🎙 "{transcription}"')
+
+    text = transcription.strip()
+    if text.startswith("---SESSION---") or text.lower().startswith("—session—"):
+        await _handle_german_transcript(update, text)
+    elif text.lower().startswith("!german"):
+        await _handle_german_command(update, text)
+    elif _DRILL_RE.search(text):
+        await _handle_german_command(update, "!german drill 3")
+    elif _SESSION_RE.search(text):
+        await _handle_german_command(update, "!german session")
+    else:
+        log_voice_note(transcription)
 
 
 def run_bot_mode():
@@ -859,6 +895,7 @@ def run_bot_mode():
     app.add_handler(CommandHandler("status", cmd_status))
     app.add_handler(CommandHandler("briefing", cmd_briefing))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text_message))
+    app.add_handler(MessageHandler(filters.VOICE, handle_voice_polling))
 
     async def error_handler(update, context):
         """Suppress noisy network errors — log one line instead of full traceback."""

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -618,9 +618,26 @@ async def _handle_german_transcript(update: Update, text: str):
     await update.message.reply_text(f"<pre>{escape(out)}</pre>", parse_mode="HTML")
 
 
+def _german_agent_mode() -> str:
+    cfg_path = GERMAN_DIR / "config" / "sync_config.json"
+    if cfg_path.exists():
+        try:
+            return json.loads(cfg_path.read_text()).get("agent_mode", "direct")
+        except Exception:
+            pass
+    return "direct"
+
+
 async def _handle_german_command(update: Update, text: str):
     parts = text.strip().split()
     cmd = parts[1].lower() if len(parts) > 1 else ""
+
+    # Respect agent_mode — openclaw mode means this bot only handles the pipeline
+    if _german_agent_mode() == "openclaw" and cmd in ("session", "drill", "writing"):
+        await update.message.reply_text(
+            "ℹ️ agent_mode is openclaw — send session commands to @minimoi_agent_bot."
+        )
+        return
 
     if cmd == "status":
         out, err, rc = _run(
@@ -706,6 +723,36 @@ async def _handle_german_command(update: Update, text: str):
         cfg_path.write_text(json.dumps(cfg, indent=2, ensure_ascii=False))
         await update.message.reply_text(f"✅ active_persona set to: {name}")
 
+    elif cmd == "writing":
+        out, err, rc = _run(
+            [str(VENV_PYTHON), "get_german_session.py",
+             "--base-dir", "language/german/", "--dropbox", "--send"],
+            cwd=str(GERMAN_BASE)
+        )
+        if rc != 0:
+            await update.message.reply_text(f"❌ get_german_session.py failed:\n{err[:400]}")
+        else:
+            await update.message.reply_text(
+                "⌨️ WRITING SESSION — Add Mode: writing to transcript header."
+            )
+
+    elif cmd == "watcher" and len(parts) > 2 and parts[2].lower() == "start":
+        import subprocess as _sp
+        script = str(GERMAN_BASE / "watch_transcripts.py")
+        _sp.Popen(
+            [str(VENV_PYTHON), script],
+            cwd=str(GERMAN_BASE),
+            start_new_session=True,
+        )
+        await update.message.reply_text("✅ Watcher started.")
+
+    elif cmd == "watcher" and len(parts) > 2 and parts[2].lower() == "stop":
+        out, err, rc = _run(["pkill", "-f", "watch_transcripts.py"])
+        if rc == 0:
+            await update.message.reply_text("✅ Watcher stopped.")
+        else:
+            await update.message.reply_text("ℹ️ Watcher was not running (or pkill failed).")
+
     elif cmd == "anki":
         anki_dir = GERMAN_DIR / "anki"
         csvs = sorted(anki_dir.glob("*.csv")) if anki_dir.exists() else []
@@ -736,11 +783,14 @@ async def _handle_german_command(update: Update, text: str):
         await update.message.reply_text(
             "German commands:\n"
             "  !german session\n"
+            "  !german writing\n"
             "  !german drill [persona] [scenario] [N]\n"
             "  !german status\n"
             "  !german progress\n"
             "  !german today\n"
             "  !german persona [name]\n"
+            "  !german watcher start\n"
+            "  !german watcher stop\n"
             "  !german anki\n"
             "  !german debug"
         )

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -726,15 +726,11 @@ async def _handle_german_command(update: Update, text: str):
     elif cmd == "writing":
         out, err, rc = _run(
             [str(VENV_PYTHON), "get_german_session.py",
-             "--base-dir", "language/german/", "--dropbox", "--send"],
+             "--base-dir", "language/german/", "--dropbox", "--send", "--writing"],
             cwd=str(GERMAN_BASE)
         )
         if rc != 0:
             await update.message.reply_text(f"❌ get_german_session.py failed:\n{err[:400]}")
-        else:
-            await update.message.reply_text(
-                "⌨️ WRITING SESSION — Add Mode: writing to transcript header."
-            )
 
     elif cmd == "watcher" and len(parts) > 2 and parts[2].lower() == "start":
         import subprocess as _sp

--- a/tools/export_pdf.py
+++ b/tools/export_pdf.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Export markdown files to PDF. Supports single files and named bundles.
+
+Usage:
+  python tools/export_pdf.py README.md
+  python tools/export_pdf.py ARCHITECTURE.md --out ~/Desktop/ARCHITECTURE.pdf
+  python tools/export_pdf.py --bundle curator
+  python tools/export_pdf.py --bundle german
+  python tools/export_pdf.py --list-bundles
+  python tools/export_pdf.py --test
+"""
+import argparse
+import sys
+from pathlib import Path
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    HRFlowable,
+    Paragraph,
+    Preformatted,
+    SimpleDocTemplate,
+    Spacer,
+)
+
+BUNDLES = {
+    "curator": [
+        ("README.md",        "README.pdf"),
+        ("ARCHITECTURE.md",  "ARCHITECTURE.pdf"),
+        ("OPERATIONS.md",    "OPERATIONS.pdf"),
+        ("ROADMAP.md",       "ROADMAP.pdf"),
+        ("VISION.md",        "VISION.pdf"),
+    ],
+    "german": [
+        ("_NewDomains/language-german/GERMAN_USER_GUIDE.md", "GERMAN_USER_GUIDE.pdf"),
+        ("_NewDomains/language-german/SPEC.md",              "GERMAN_SPEC.pdf"),
+    ],
+}
+
+
+def _find_repo_root() -> Path:
+    p = Path(__file__).resolve().parent
+    while p != p.parent:
+        if (p / ".git").exists():
+            return p
+        p = p.parent
+    return Path(__file__).resolve().parent.parent
+
+
+def _styles() -> dict:
+    base = getSampleStyleSheet()
+    # GitHub-flavored styling: dark charcoal text, light gray code bg, Helvetica sans-serif
+    text_color = colors.HexColor("#1f2328")
+    muted_color = colors.HexColor("#636c76")
+    code_bg = colors.HexColor("#f6f8fa")
+    border_color = colors.HexColor("#d0d7de")
+
+    body = ParagraphStyle("Body", parent=base["Normal"], fontSize=10,
+                          fontName="Helvetica", spaceAfter=6, leading=15,
+                          textColor=text_color)
+    return {
+        "h1": ParagraphStyle("H1", parent=base["Heading1"], fontSize=18,
+                             fontName="Helvetica-Bold", spaceAfter=10,
+                             spaceBefore=4, textColor=text_color),
+        "h2": ParagraphStyle("H2", parent=base["Heading2"], fontSize=14,
+                             fontName="Helvetica-Bold", spaceAfter=8,
+                             spaceBefore=18, textColor=text_color),
+        "h3": ParagraphStyle("H3", parent=base["Heading3"], fontSize=12,
+                             fontName="Helvetica-Bold", spaceAfter=6,
+                             spaceBefore=14, textColor=text_color),
+        "body": body,
+        "bullet": ParagraphStyle("Bullet", parent=body, leftIndent=20,
+                                 spaceAfter=3),
+        "code": ParagraphStyle("Code", parent=base["Code"], fontSize=8.5,
+                               leading=13, backColor=code_bg,
+                               borderPadding=8, leftIndent=10, rightIndent=10,
+                               spaceAfter=10, spaceBefore=6,
+                               fontName="Courier", textColor=text_color),
+        "meta": ParagraphStyle("Meta", parent=body, fontSize=9,
+                               textColor=muted_color),
+        "bq": ParagraphStyle("BQ", parent=body, fontSize=10, leftIndent=16,
+                             textColor=muted_color),
+    }
+
+
+def _escape(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def _apply_inline(text: str) -> str:
+    while "**" in text:
+        text = text.replace("**", "<b>", 1).replace("**", "</b>", 1)
+    while "`" in text:
+        text = text.replace("`", "<font name='Courier' size='9'>", 1).replace("`", "</font>", 1)
+    return text
+
+
+def render_md_to_pdf(src: Path, out: Path, title: str = "") -> None:
+    if not title:
+        title = src.stem.replace("_", " ").replace("-", " ").title()
+
+    st = _styles()
+    doc = SimpleDocTemplate(
+        str(out), pagesize=letter,
+        leftMargin=inch, rightMargin=inch,
+        topMargin=inch, bottomMargin=inch,
+        title=title, author="Robert van Stedum",
+    )
+
+    lines = src.read_text(encoding="utf-8").splitlines()
+    story = []
+    i = 0
+    in_code = False
+    code_buf = []
+
+    while i < len(lines):
+        line = lines[i]
+
+        if line.strip().startswith("```"):
+            if not in_code:
+                in_code = True
+                code_buf = []
+            else:
+                in_code = False
+                story.append(Preformatted("\n".join(code_buf), st["code"]))
+            i += 1
+            continue
+
+        if in_code:
+            code_buf.append(line)
+            i += 1
+            continue
+
+        if line.strip() == "---":
+            story.append(HRFlowable(width="100%", thickness=0.5,
+                                    color=colors.HexColor("#d0d7de"),
+                                    spaceAfter=8, spaceBefore=8))
+            i += 1
+            continue
+
+        if line.startswith("# ") and not line.startswith("## "):
+            story.append(Paragraph(_escape(line[2:]), st["h1"]))
+            i += 1
+            continue
+        if line.startswith("## "):
+            story.append(Paragraph(_escape(line[3:]), st["h2"]))
+            i += 1
+            continue
+        if line.startswith("### "):
+            story.append(Paragraph(_escape(line[4:]), st["h3"]))
+            i += 1
+            continue
+
+        if line.startswith("**") and line.count("**") >= 2:
+            text = _escape(line).replace("**", "<b>", 1).replace("**", "</b>", 1)
+            story.append(Paragraph(text, st["meta"]))
+            i += 1
+            continue
+
+        if line.startswith("> "):
+            story.append(Paragraph(_escape(line[2:]), st["bq"]))
+            i += 1
+            continue
+
+        if line.startswith("- "):
+            text = _apply_inline(_escape(line[2:]))
+            story.append(Paragraph("• " + text, st["bullet"]))
+            i += 1
+            continue
+
+        if len(line) > 2 and line[0].isdigit() and line[1] in ".)":
+            text = _apply_inline(_escape(line[2:].strip()))
+            story.append(Paragraph(line[0] + ". " + text, st["bullet"]))
+            i += 1
+            continue
+
+        if line.startswith("|"):
+            table_lines = []
+            while i < len(lines) and lines[i].startswith("|"):
+                if not all(c in "|-: " for c in lines[i]):
+                    table_lines.append(lines[i])
+                i += 1
+            if table_lines:
+                story.append(Preformatted("\n".join(table_lines), st["code"]))
+            continue
+
+        if line.strip() == "":
+            story.append(Spacer(1, 4))
+            i += 1
+            continue
+
+        story.append(Paragraph(_apply_inline(_escape(line)), st["body"]))
+        i += 1
+
+    doc.build(story)
+
+
+def _run_tests() -> None:
+    repo_root = _find_repo_root()
+    downloads = Path.home() / "Downloads"
+    test_out = downloads / "export_pdf_test.pdf"
+    results = []
+
+    # Test 1: Bundle resolution — at least one bundle has files that exist on disk
+    try:
+        found = False
+        for bundle_name in ("curator", "german"):
+            entries = BUNDLES.get(bundle_name, [])
+            if any((repo_root / src_rel).exists() for src_rel, _ in entries):
+                found = True
+                break
+        results.append(("Test 1 — Bundle resolution", found, None))
+    except Exception as e:
+        results.append(("Test 1 — Bundle resolution", False, str(e)))
+
+    # Test 2: Single file conversion — README.md converts without error
+    readme = repo_root / "README.md"
+    converted = False
+    try:
+        if not readme.exists():
+            raise FileNotFoundError(f"README.md not found at {readme}")
+        render_md_to_pdf(readme, test_out)
+        converted = True
+        results.append(("Test 2 — Single file conversion", True, None))
+    except Exception as e:
+        results.append(("Test 2 — Single file conversion", False, str(e)))
+
+    # Test 3: Output validation — file is in ~/Downloads/ and non-zero bytes
+    try:
+        if not converted:
+            raise RuntimeError("Skipped — conversion failed in Test 2")
+        size = test_out.stat().st_size if test_out.exists() else 0
+        ok = test_out.exists() and size > 0
+        results.append(("Test 3 — Output non-zero bytes", ok,
+                        None if ok else f"size={size}, exists={test_out.exists()}"))
+    except Exception as e:
+        results.append(("Test 3 — Output non-zero bytes", False, str(e)))
+    finally:
+        if test_out.exists():
+            test_out.unlink()
+
+    print()
+    all_pass = True
+    for label, passed, detail in results:
+        status = "PASS" if passed else "FAIL"
+        print(f"{label + ':':<42} {status}")
+        if not passed and detail:
+            print(f"         {detail}")
+        if not passed:
+            all_pass = False
+
+    print()
+    if all_pass:
+        print("All tests passed.")
+    else:
+        print("One or more tests FAILED.")
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export markdown files to PDF.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("file", nargs="?", help="Markdown file to export")
+    parser.add_argument("--out", help="Output PDF path (default: ~/Downloads/<name>.pdf)")
+    parser.add_argument("--bundle", choices=list(BUNDLES.keys()),
+                        help="Export a predefined bundle of documents")
+    parser.add_argument("--list-bundles", action="store_true",
+                        help="List available bundles and their contents")
+    parser.add_argument("--test", action="store_true",
+                        help="Run self-tests and report results")
+    args = parser.parse_args()
+
+    if args.test:
+        _run_tests()
+        return
+
+    if args.list_bundles:
+        for name, entries in BUNDLES.items():
+            print(f"\n  {name}:")
+            for src_rel, out_name in entries:
+                print(f"    {src_rel}  →  ~/Downloads/{out_name}")
+        print()
+        return
+
+    downloads = Path.home() / "Downloads"
+    repo_root = _find_repo_root()
+
+    if args.bundle:
+        entries = BUNDLES[args.bundle]
+        print(f"\nExporting bundle '{args.bundle}' ({len(entries)} files)…")
+        for src_rel, out_name in entries:
+            src = repo_root / src_rel
+            out = downloads / out_name
+            if not src.exists():
+                print(f"  ⚠️  Not found, skipping: {src_rel}")
+                continue
+            render_md_to_pdf(src, out)
+            print(f"  ✅ {out_name}")
+        print()
+        return
+
+    if not args.file:
+        parser.print_help()
+        sys.exit(1)
+
+    src = Path(args.file)
+    if not src.is_absolute():
+        src = Path.cwd() / src
+    if not src.exists():
+        print(f"Error: file not found: {src}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.out:
+        out = Path(args.out).expanduser()
+    else:
+        out = downloads / (src.stem + ".pdf")
+
+    render_md_to_pdf(src, out)
+    print(f"✅ PDF saved: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/export_pdf.py
+++ b/tools/export_pdf.py
@@ -49,6 +49,30 @@ def _find_repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
+def _output_dir() -> Path:
+    """Resolve default output directory.
+
+    Priority: tools_config.json export_pdf_output_dir → script's own directory.
+    Creates the directory if it doesn't exist.
+    """
+    import json
+    config_path = Path(__file__).parent / "tools_config.json"
+    if config_path.exists():
+        try:
+            cfg = json.loads(config_path.read_text())
+            raw = cfg.get("export_pdf_output_dir", "")
+            if raw:
+                d = Path(raw).expanduser().resolve()
+                d.mkdir(parents=True, exist_ok=True)
+                return d
+        except Exception:
+            pass
+    # Fallback: same directory as this script
+    d = Path(__file__).parent.resolve()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
 def _styles() -> dict:
     base = getSampleStyleSheet()
     # GitHub-flavored styling: dark charcoal text, light gray code bg, Helvetica sans-serif
@@ -199,8 +223,8 @@ def render_md_to_pdf(src: Path, out: Path, title: str = "") -> None:
 
 def _run_tests() -> None:
     repo_root = _find_repo_root()
-    downloads = Path.home() / "Downloads"
-    test_out = downloads / "export_pdf_test.pdf"
+    out_dir = _output_dir()
+    test_out = out_dir / "export_pdf_test.pdf"
     results = []
 
     # Test 1: Bundle resolution — at least one bundle has files that exist on disk
@@ -227,7 +251,7 @@ def _run_tests() -> None:
     except Exception as e:
         results.append(("Test 2 — Single file conversion", False, str(e)))
 
-    # Test 3: Output validation — file is in ~/Downloads/ and non-zero bytes
+    # Test 3: Output validation — file exists in output dir and is non-zero bytes
     try:
         if not converted:
             raise RuntimeError("Skipped — conversion failed in Test 2")
@@ -266,7 +290,7 @@ def main() -> None:
         epilog=__doc__,
     )
     parser.add_argument("file", nargs="?", help="Markdown file to export")
-    parser.add_argument("--out", help="Output PDF path (default: ~/Downloads/<name>.pdf)")
+    parser.add_argument("--out", help="Output PDF path (overrides configured output dir)")
     parser.add_argument("--bundle", choices=list(BUNDLES.keys()),
                         help="Export a predefined bundle of documents")
     parser.add_argument("--list-bundles", action="store_true",
@@ -279,23 +303,23 @@ def main() -> None:
         _run_tests()
         return
 
+    out_dir = _output_dir()
+    repo_root = _find_repo_root()
+
     if args.list_bundles:
         for name, entries in BUNDLES.items():
             print(f"\n  {name}:")
             for src_rel, out_name in entries:
-                print(f"    {src_rel}  →  ~/Downloads/{out_name}")
+                print(f"    {src_rel}  →  {out_dir}/{out_name}")
         print()
         return
-
-    downloads = Path.home() / "Downloads"
-    repo_root = _find_repo_root()
 
     if args.bundle:
         entries = BUNDLES[args.bundle]
         print(f"\nExporting bundle '{args.bundle}' ({len(entries)} files)…")
         for src_rel, out_name in entries:
             src = repo_root / src_rel
-            out = downloads / out_name
+            out = out_dir / out_name
             if not src.exists():
                 print(f"  ⚠️  Not found, skipping: {src_rel}")
                 continue
@@ -318,7 +342,7 @@ def main() -> None:
     if args.out:
         out = Path(args.out).expanduser()
     else:
-        out = downloads / (src.stem + ".pdf")
+        out = out_dir / (src.stem + ".pdf")
 
     render_md_to_pdf(src, out)
     print(f"✅ PDF saved: {out}")

--- a/tools/tools_config.json
+++ b/tools/tools_config.json
@@ -1,0 +1,3 @@
+{
+  "export_pdf_output_dir": "_working"
+}


### PR DESCRIPTION
## Summary

- **Transcript parser now tolerates imperfect Grok formatting**: handles concatenated header/body (no newline between `Mode: voice` and first speaker), inline speaker turns separated only by punctuation, wrong or missing `Mode` value — all produce a clean session rather than a hard fail
- **Writing session routing via natural language**: typing "next session german writing" or similar now correctly delivers the writing prompt (`Mode: writing`) instead of the voice prompt
- **Reviewer fix**: strips markdown code fences from LLM JSON output; raises `max_tokens` 2048 → 4096 to prevent truncated responses

## Key usability improvement

Previously, Grok's session footer sometimes produced `Mode: voiceDr. Huber: ...` (value concatenated with first speaker, no newline), causing the parser to crash with "fewer than 2 turns found". Now:
- Any scalar header field (`Mode`, `Duration`, `Date`) concatenated with the conversation body is automatically split
- Unknown `Mode` values warn and default to `writing` — no crash
- Speaker names following sentence-ending punctuation (`.?!`) are correctly detected as turn boundaries

## Also in this branch

- `get_german_session.py` — agent-agnostic session package delivery with `--send`, `--writing`, `--dropbox` flags
- Universal session header + transcript footer for all AI models
- Dropbox bridge (`watch_transcripts.py`) + drill mode
- ORCHESTRATOR.md direct mode — bypasses OpenClaw for session commands
- Fuzzy parser: Format 3 key line, lesson inference, duration estimate
- `scripts/store_key.py` — generalized macOS Keychain setup utility
- Various persona/prompt refinements and test suite additions (9 tests)

## Test plan
- [x] 9/9 `run_tests.py` pass
- [x] Writing session transcript with concatenated `Mode: writingDr. Huber:` parses to 5 turns, `mode: writing`
- [x] "next session german writing" in Telegram → writing prompt with `Mode: writing` in footer
- [x] Reviewer processes writing session transcript end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)