### PR TITLE
refactor(domain): extract german_domain.py — Groups A, B, C, D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ curator_media/
 context/
 
 # Working/scratch files — short-term, not for repo
-_working/
+_working/*
 # Build notes are permanent reasoning artifacts — commit them
 !_working/build_note_*.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ context/
 
 # Working/scratch files — short-term, not for repo
 _working/
+# Build notes are permanent reasoning artifacts — commit them
+!_working/build_note_*.md
 
 # Finance domain — private data
 domains/finance/statements/

--- a/_NewDomains/language-german/test_german_domain.py
+++ b/_NewDomains/language-german/test_german_domain.py
@@ -5,8 +5,11 @@ Usage:
     python3 test_german_domain.py          # run all tests
     python3 test_german_domain.py --test 3 # run single test
 
-After each run, writes results to:
-    ../../_working/test_german_domain_results_YYYYMMDD.md
+After each run, appends a dated report to:
+    ../../_working/test_german_domain_results_YYYYMMDD_HHMM.md
+
+Failures are shown prominently at the end of stdout and at the top of each report.
+All runs are kept; run `python3 test_german_domain.py --stats` for a build-phase summary.
 """
 
 import sys
@@ -33,12 +36,15 @@ from german_domain import (
 
 _results: list[dict] = []
 
-def report(test_num: str, name: str, passed: bool, detail: str = "") -> None:
+def report(test_num: str, name: str, passed: bool, detail: str = "", *, expected: str = "", got: str = "") -> None:
     status = "PASS" if passed else "FAIL"
     label = f"Test {test_num} — {name}"
     suffix = f": {detail}" if detail else ""
     print(f"{label}: {status}{suffix}")
-    _results.append({"num": test_num, "name": name, "status": status, "detail": detail})
+    _results.append({
+        "num": test_num, "name": name, "status": status,
+        "detail": detail, "expected": expected, "got": got,
+    })
 
 # ─── Sample data ─────────────────────────────────────────────────────────────
 
@@ -64,8 +70,9 @@ SAMPLE_ENTRY = SAMPLE_POOL["core"]["verbs"][0]  # nehmen
 def test_D01():
     name = "_normalize_answer: lowercase, strip punctuation, collapse whitespace"
     result = _normalize_answer("Ich BIN  müde!")
-    passed = result == "ich bin müde"
-    report("D01", name, passed, repr(result))
+    expected = "ich bin müde"
+    passed = result == expected
+    report("D01", name, passed, repr(result), expected=repr(expected), got=repr(result))
 
 def test_D02():
     name = "_expand_contractions: im → in dem, ins → in das, no-op on unknown"
@@ -85,7 +92,8 @@ def test_D03():
     r2 = _parse_spoken_id("three")
     r3 = _parse_spoken_id("5")
     passed = r1 == "001" and r2 == "003" and r3 == "005"
-    report("D03", name, passed, f"one={r1}, three={r2}, 5={r3}")
+    report("D03", name, passed, f"one={r1}, three={r2}, 5={r3}",
+           expected="001, 003, 005", got=f"{r1}, {r2}, {r3}")
 
 def test_D04():
     name = "_lookup_verb: found in pool, not found returns None"
@@ -233,16 +241,52 @@ ALL_TESTS = [
     test_D11, test_D12, test_D13, test_D14, test_D15,
 ]
 
-def _write_results_md():
-    today = datetime.now().strftime("%Y%m%d")
-    out_path = REPO_ROOT / "_working" / f"test_german_domain_results_{today}.md"
+WORKING_DIR = REPO_ROOT / "_working"
+
+def _print_failure_summary() -> None:
+    failures = [r for r in _results if r["status"] == "FAIL"]
+    if not failures:
+        return
+    print("\n" + "─" * 60)
+    print(f"FAILURES ({len(failures)}):")
+    for r in failures:
+        print(f"\n  ❌ {r['num']} — {r['name']}")
+        if r.get("expected"):
+            print(f"     expected : {r['expected']}")
+            print(f"     got      : {r['got']}")
+        elif r.get("detail"):
+            print(f"     detail   : {r['detail']}")
+    print("─" * 60)
+
+def _write_results_md(run_ts: str) -> Path:
+    out_path = WORKING_DIR / f"test_german_domain_{run_ts}.md"
     passed = sum(1 for r in _results if r["status"] == "PASS")
-    total = len(_results)
+    failed = sum(1 for r in _results if r["status"] == "FAIL")
+    total  = len(_results)
+
     lines = [
-        f"# german_domain.py — Test Results",
-        f"**Run:** {datetime.now().strftime('%Y-%m-%d %H:%M')}  ",
+        "# german_domain.py — Test Results",
+        f"**Run:** {run_ts.replace('_', ' ')}  ",
         f"**Suite:** Group A (constants + pure functions)  ",
-        f"**Result:** {passed}/{total} passed",
+        f"**Result:** {passed}/{total} passed" + (f" — **{failed} FAILED**" if failed else ""),
+        "",
+    ]
+
+    failures = [r for r in _results if r["status"] == "FAIL"]
+    if failures:
+        lines += ["## Failures", ""]
+        for r in failures:
+            lines.append(f"### ❌ {r['num']} — {r['name']}")
+            if r.get("expected"):
+                lines.append(f"- **Expected:** `{r['expected']}`")
+                lines.append(f"- **Got:** `{r['got']}`")
+            if r.get("detail"):
+                lines.append(f"- **Detail:** {r['detail']}")
+            lines.append("")
+        lines += ["---", ""]
+
+    lines += [
+        "## Full Results",
         "",
         "| # | Test | Status | Detail |",
         "|---|------|--------|--------|",
@@ -251,13 +295,38 @@ def _write_results_md():
         icon = "✅" if r["status"] == "PASS" else "❌"
         detail = r["detail"].replace("|", "\\|")
         lines.append(f"| {r['num']} | {r['name']} | {icon} {r['status']} | {detail} |")
+
     out_path.write_text("\n".join(lines) + "\n")
-    print(f"\nResults written to: {out_path}")
+    return out_path
+
+def _print_stats() -> None:
+    """Print a summary of all saved test runs — defects found and fixed during build."""
+    reports = sorted(WORKING_DIR.glob("test_german_domain_*.md"))
+    if not reports:
+        print("No reports found in _working/.")
+        return
+    print(f"\nBuild phase stats — {len(reports)} run(s) found:\n")
+    total_failures = 0
+    for p in reports:
+        text = p.read_text()
+        run_ts = p.stem.replace("test_german_domain_", "")
+        result_line = next((l for l in text.splitlines() if "passed" in l and "**Result:**" in l), "")
+        fail_count = text.count("❌")
+        total_failures += fail_count
+        print(f"  {run_ts}  {result_line.replace('**Result:** ', '').strip()}")
+    print(f"\n  Total failure instances across all runs: {total_failures}")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--test", type=str, help="Run single test by number, e.g. D03")
+    parser.add_argument("--stats", action="store_true", help="Show build-phase defect stats across all saved runs")
     args = parser.parse_args()
+
+    if args.stats:
+        _print_stats()
+        sys.exit(0)
+
+    run_ts = datetime.now().strftime("%Y%m%d_%H%M")
 
     if args.test:
         target = args.test.upper().lstrip("0") or "0"
@@ -272,7 +341,9 @@ if __name__ == "__main__":
             t()
 
     passed = sum(1 for r in _results if r["status"] == "PASS")
-    total = len(_results)
+    total  = len(_results)
+    _print_failure_summary()
     print(f"\n{passed}/{total} tests passed.")
-    _write_results_md()
+    out_path = _write_results_md(run_ts)
+    print(f"Report: {out_path}")
     sys.exit(0 if passed == total else 1)

--- a/_NewDomains/language-german/test_german_domain.py
+++ b/_NewDomains/language-german/test_german_domain.py
@@ -2,25 +2,19 @@
 test_german_domain.py — Test suite for german_domain.py (Group A)
 
 Usage:
-    python3 test_german_domain.py          # run all tests
-    python3 test_german_domain.py --test 3 # run single test
-
-After each run, appends a dated report to:
-    ../../_working/test_german_domain_results_YYYYMMDD_HHMM.md
-
-Failures are shown prominently at the end of stdout and at the top of each report.
-All runs are kept; run `python3 test_german_domain.py --stats` for a build-phase summary.
+    python3 _NewDomains/language-german/test_german_domain.py
+    python3 _NewDomains/language-german/test_german_domain.py --test D03
+    python3 test_reporter.py --stats --suite german_domain
 """
 
 import sys
 import argparse
 from pathlib import Path
-from datetime import datetime
 
-# Make german_domain importable from repo root
 REPO_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+from test_reporter import TestReporter, print_stats
 from german_domain import (
     _normalize_answer, _expand_contractions, _parse_spoken_id,
     _lookup_verb, _all_verb_entries,
@@ -32,19 +26,8 @@ from german_domain import (
     GERMAN_DIR, GERMAN_BASE,
 )
 
-# ─── Test runner ─────────────────────────────────────────────────────────────
-
-_results: list[dict] = []
-
-def report(test_num: str, name: str, passed: bool, detail: str = "", *, expected: str = "", got: str = "") -> None:
-    status = "PASS" if passed else "FAIL"
-    label = f"Test {test_num} — {name}"
-    suffix = f": {detail}" if detail else ""
-    print(f"{label}: {status}{suffix}")
-    _results.append({
-        "num": test_num, "name": name, "status": status,
-        "detail": detail, "expected": expected, "got": got,
-    })
+runner = TestReporter(suite="german_domain", group="Group A")
+report = runner.report
 
 # ─── Sample data ─────────────────────────────────────────────────────────────
 
@@ -241,92 +224,10 @@ ALL_TESTS = [
     test_D11, test_D12, test_D13, test_D14, test_D15,
 ]
 
-WORKING_DIR = REPO_ROOT / "_working"
-
-def _print_failure_summary() -> None:
-    failures = [r for r in _results if r["status"] == "FAIL"]
-    if not failures:
-        return
-    print("\n" + "─" * 60)
-    print(f"FAILURES ({len(failures)}):")
-    for r in failures:
-        print(f"\n  ❌ {r['num']} — {r['name']}")
-        if r.get("expected"):
-            print(f"     expected : {r['expected']}")
-            print(f"     got      : {r['got']}")
-        elif r.get("detail"):
-            print(f"     detail   : {r['detail']}")
-    print("─" * 60)
-
-def _write_results_md(run_ts: str) -> Path:
-    out_path = WORKING_DIR / f"test_german_domain_{run_ts}.md"
-    passed = sum(1 for r in _results if r["status"] == "PASS")
-    failed = sum(1 for r in _results if r["status"] == "FAIL")
-    total  = len(_results)
-
-    lines = [
-        "# german_domain.py — Test Results",
-        f"**Run:** {run_ts.replace('_', ' ')}  ",
-        f"**Suite:** Group A (constants + pure functions)  ",
-        f"**Result:** {passed}/{total} passed" + (f" — **{failed} FAILED**" if failed else ""),
-        "",
-    ]
-
-    failures = [r for r in _results if r["status"] == "FAIL"]
-    if failures:
-        lines += ["## Failures", ""]
-        for r in failures:
-            lines.append(f"### ❌ {r['num']} — {r['name']}")
-            if r.get("expected"):
-                lines.append(f"- **Expected:** `{r['expected']}`")
-                lines.append(f"- **Got:** `{r['got']}`")
-            if r.get("detail"):
-                lines.append(f"- **Detail:** {r['detail']}")
-            lines.append("")
-        lines += ["---", ""]
-
-    lines += [
-        "## Full Results",
-        "",
-        "| # | Test | Status | Detail |",
-        "|---|------|--------|--------|",
-    ]
-    for r in _results:
-        icon = "✅" if r["status"] == "PASS" else "❌"
-        detail = r["detail"].replace("|", "\\|")
-        lines.append(f"| {r['num']} | {r['name']} | {icon} {r['status']} | {detail} |")
-
-    out_path.write_text("\n".join(lines) + "\n")
-    return out_path
-
-def _print_stats() -> None:
-    """Print a summary of all saved test runs — defects found and fixed during build."""
-    reports = sorted(WORKING_DIR.glob("test_german_domain_*.md"))
-    if not reports:
-        print("No reports found in _working/.")
-        return
-    print(f"\nBuild phase stats — {len(reports)} run(s) found:\n")
-    total_failures = 0
-    for p in reports:
-        text = p.read_text()
-        run_ts = p.stem.replace("test_german_domain_", "")
-        result_line = next((l for l in text.splitlines() if "passed" in l and "**Result:**" in l), "")
-        fail_count = text.count("❌")
-        total_failures += fail_count
-        print(f"  {run_ts}  {result_line.replace('**Result:** ', '').strip()}")
-    print(f"\n  Total failure instances across all runs: {total_failures}")
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--test", type=str, help="Run single test by number, e.g. D03")
-    parser.add_argument("--stats", action="store_true", help="Show build-phase defect stats across all saved runs")
     args = parser.parse_args()
-
-    if args.stats:
-        _print_stats()
-        sys.exit(0)
-
-    run_ts = datetime.now().strftime("%Y%m%d_%H%M")
 
     if args.test:
         target = args.test.upper().lstrip("0") or "0"
@@ -340,10 +241,4 @@ if __name__ == "__main__":
         for t in ALL_TESTS:
             t()
 
-    passed = sum(1 for r in _results if r["status"] == "PASS")
-    total  = len(_results)
-    _print_failure_summary()
-    print(f"\n{passed}/{total} tests passed.")
-    out_path = _write_results_md(run_ts)
-    print(f"Report: {out_path}")
-    sys.exit(0 if passed == total else 1)
+    runner.finish()

--- a/_NewDomains/language-german/test_german_domain.py
+++ b/_NewDomains/language-german/test_german_domain.py
@@ -31,6 +31,8 @@ from german_domain import (
     _load_keyword_map_bot,
     _call_llm, _fetch_conjugations, _fetch_phrases,
     _write_drill_anki, _drill_completion_message,
+    # Group C
+    _resolve_verb, _resolve_phrases, _resolve_drill_verb,
 )
 import german_domain
 import tempfile, unittest.mock as mock
@@ -406,6 +408,53 @@ def test_D27():
     report("D27", name, passed, repr(msg[:120]))
 
 
+def test_D28():
+    name = "_resolve_verb: returns entry immediately when verb already in pool (progress_cb=None)"
+    pool = {"core": {"verbs": [{"verb": "nehmen", "english": "to take", "conjugations": {}}]}}
+    with mock.patch("german_domain._load_drill_pool", return_value=pool):
+        result = _resolve_verb("nehmen", progress_cb=None)
+    passed = result is not None and result["verb"] == "nehmen"
+    report("D28", name, passed, f"verb={result and result['verb']}", expected="nehmen", got=str(result and result['verb']))
+
+def test_D29():
+    name = "_resolve_verb: calls progress_cb with 'Looking up' when verb not in pool"
+    pool = {"core": {"verbs": []}, "on_demand": {"verbs": []}}
+    conj = {"verb": "nehmen", "english": "to take", "conjugations": {"ich": "nehme"}}
+    messages = []
+    def _cb(msg): messages.append(msg)
+    with mock.patch("german_domain._load_drill_pool", return_value=pool), \
+         mock.patch("german_domain._save_drill_pool"), \
+         mock.patch("german_domain._fetch_conjugations", return_value=conj):
+        result = _resolve_verb("nehmen", progress_cb=_cb)
+    passed = result is not None and any("Looking up" in m for m in messages)
+    report("D29", name, passed, f"messages={messages}", expected="'Looking up' in callback", got=str(messages))
+
+def test_D30():
+    name = "_resolve_phrases: returns cached phrases without calling progress_cb (progress_cb=None)"
+    entry = {"verb": "nehmen", "english": "to take", "phrases": [{"english": "I take it", "german": "Ich nehme es"}]}
+    result = _resolve_phrases(entry, progress_cb=None)
+    passed = result == entry["phrases"]
+    report("D30", name, passed, f"count={len(result)}", expected="1 phrase", got=str(len(result)))
+
+def test_D31():
+    name = "_resolve_drill_verb: returns entry for known verb in pool (progress_cb=None)"
+    pool = {"core": {"verbs": [{"verb": "nehmen", "english": "to take", "conjugations": {}}]}}
+    with mock.patch("german_domain._load_drill_pool", return_value=pool):
+        result = _resolve_drill_verb("drill nehmen", progress_cb=None)
+    passed = result is not None and result["verb"] == "nehmen"
+    report("D31", name, passed, f"verb={result and result['verb']}", expected="nehmen", got=str(result and result['verb']))
+
+def test_D32():
+    name = "_resolve_drill_verb: callback fired when scene keyword resolves to verb"
+    pool = {"core": {"verbs": [{"verb": "nehmen", "english": "to take", "conjugations": {}, "scenes": ["cafe"]}]}}
+    messages = []
+    def _cb(msg): messages.append(msg)
+    with mock.patch("german_domain._load_drill_pool", return_value=pool):
+        result = _resolve_drill_verb("drill cafe", progress_cb=_cb)
+    passed = result is not None and any("scene" in m for m in messages)
+    report("D32", name, passed, f"verb={result and result['verb']}, cb_msgs={messages}", expected="scene in callback", got=str(messages))
+
+
 # ─── Main runner ──────────────────────────────────────────────────────────────
 
 ALL_TESTS = [
@@ -415,6 +464,7 @@ ALL_TESTS = [
     test_D16, test_D17, test_D18, test_D19, test_D20,
     test_D21, test_D22, test_D23, test_D24, test_D25,
     test_D26, test_D27,
+    test_D28, test_D29, test_D30, test_D31, test_D32,
 ]
 
 if __name__ == "__main__":

--- a/_NewDomains/language-german/test_german_domain.py
+++ b/_NewDomains/language-german/test_german_domain.py
@@ -24,9 +24,18 @@ from german_domain import (
     _SESSION_RE, _DRILL_RE, _DRILL_LIST_RE,
     _DRILL_CTL_RE, _PHRASE_CAPTURE_RE, _AGAIN_RE,
     GERMAN_DIR, GERMAN_BASE,
+    # Group B
+    _phrase_next_id, _run,
+    _load_drill_pool, _save_drill_pool,
+    _load_phrasebook, _save_phrasebook,
+    _load_keyword_map_bot,
+    _call_llm, _fetch_conjugations, _fetch_phrases,
+    _write_drill_anki, _drill_completion_message,
 )
+import german_domain
+import tempfile, unittest.mock as mock
 
-runner = TestReporter(suite="german_domain", group="Group A")
+runner = TestReporter(suite="german_domain", group="Group A+B")
 report = runner.report
 
 # ─── Sample data ─────────────────────────────────────────────────────────────
@@ -216,12 +225,196 @@ def test_D15():
     report("D15", name, passed,
            f"session={session_ok} drill={drill_ok} list={list_ok} again={again_ok} ctl={ctl_ok} phrase={phrase_ok}")
 
+# ─── Group B tests ────────────────────────────────────────────────────────────
+
+def test_D16():
+    name = "_phrase_next_id: first ID, global max sequence, date prefix"
+    empty = _phrase_next_id([], "2026-05-19")
+    phrases = [{"id": "ph_20260512_001"}, {"id": "ph_20260514_003"}]
+    next_id = _phrase_next_id(phrases, "2026-05-19")
+    passed = (
+        empty == "ph_20260519_001" and
+        next_id == "ph_20260519_004"
+    )
+    report("D16", name, passed, expected="ph_20260519_001 / ph_20260519_004",
+           got=f"{empty} / {next_id}")
+
+def test_D17():
+    name = "_run: returns (stdout, stderr, returncode) tuple"
+    out, err, rc = _run(["echo", "hello"])
+    passed = rc == 0 and "hello" in out and isinstance(err, str)
+    report("D17", name, passed, f"rc={rc}, out={out.strip()!r}", expected="rc=0", got=f"rc={rc}")
+
+def test_D18():
+    name = "_load_drill_pool: returns {} when file missing; loads dict when present"
+    with tempfile.TemporaryDirectory() as tmp:
+        original = german_domain.GERMAN_DIR
+        fake_dir = Path(tmp)
+        (fake_dir / "config").mkdir()
+        german_domain.GERMAN_DIR = fake_dir
+        try:
+            missing = _load_drill_pool()
+            pool_path = fake_dir / "config" / "drill_pool.json"
+            pool_path.write_text('{"core": {"verbs": []}}')
+            loaded = _load_drill_pool()
+        finally:
+            german_domain.GERMAN_DIR = original
+    passed = missing == {} and loaded == {"core": {"verbs": []}}
+    report("D18", name, passed, f"missing={missing}, loaded={loaded}")
+
+def test_D19():
+    name = "_save_drill_pool + _load_drill_pool: round-trip preserves data"
+    with tempfile.TemporaryDirectory() as tmp:
+        original = german_domain.GERMAN_DIR
+        fake_dir = Path(tmp)
+        (fake_dir / "config").mkdir()
+        german_domain.GERMAN_DIR = fake_dir
+        try:
+            data = {"core": {"verbs": [{"verb": "nehmen"}]}}
+            _save_drill_pool(data)
+            loaded = _load_drill_pool()
+        finally:
+            german_domain.GERMAN_DIR = original
+    passed = loaded == data
+    report("D19", name, passed, expected=str(data), got=str(loaded))
+
+def test_D20():
+    name = "_load_phrasebook: returns {'phrases': []} when missing; loads correctly"
+    with tempfile.TemporaryDirectory() as tmp:
+        original = german_domain._PHRASEBOOK_FILE
+        german_domain._PHRASEBOOK_FILE = Path(tmp) / "phrasebook.json"
+        try:
+            missing = _load_phrasebook()
+            german_domain._PHRASEBOOK_FILE.write_text('{"phrases": [{"id": "ph_001"}]}')
+            loaded = _load_phrasebook()
+        finally:
+            german_domain._PHRASEBOOK_FILE = original
+    passed = missing == {"phrases": []} and loaded["phrases"][0]["id"] == "ph_001"
+    report("D20", name, passed, f"missing={missing}, loaded_count={len(loaded.get('phrases',[]))}")
+
+def test_D21():
+    name = "_save_phrasebook + _load_phrasebook: round-trip preserves data"
+    with tempfile.TemporaryDirectory() as tmp:
+        original = german_domain._PHRASEBOOK_FILE
+        german_domain._PHRASEBOOK_FILE = Path(tmp) / "phrasebook.json"
+        try:
+            data = {"phrases": [{"id": "ph_20260519_001", "german": "Ich nehme es", "english": "I'll take it"}]}
+            _save_phrasebook(data)
+            loaded = _load_phrasebook()
+        finally:
+            german_domain._PHRASEBOOK_FILE = original
+    passed = loaded == data
+    report("D21", name, passed, expected="round-trip match", got="match" if loaded == data else f"got {loaded}")
+
+def test_D22():
+    name = "_load_keyword_map_bot: returns {} when missing; loads dict when present"
+    with tempfile.TemporaryDirectory() as tmp:
+        original = german_domain.GERMAN_DIR
+        fake_dir = Path(tmp)
+        (fake_dir / "config").mkdir()
+        german_domain.GERMAN_DIR = fake_dir
+        try:
+            missing = _load_keyword_map_bot()
+            kmap = {"Georg": {"trigger_words": ["Georg"], "default_scenario": "coffee"}}
+            (fake_dir / "config" / "keyword_map.json").write_text(
+                __import__("json").dumps(kmap)
+            )
+            loaded = _load_keyword_map_bot()
+        finally:
+            german_domain.GERMAN_DIR = original
+    passed = missing == {} and "Georg" in loaded
+    report("D22", name, passed, f"missing={missing}, loaded_keys={list(loaded.keys())}")
+
+def test_D23():
+    name = "_call_llm: returns None when provider list is empty (no providers to try)"
+    with mock.patch("german_domain._LLM_PROVIDERS", []):
+        result = _call_llm("test prompt", max_tokens=10)
+    passed = result is None
+    report("D23", name, passed, f"result={result!r}", expected="None", got=repr(result))
+
+def test_D24():
+    name = "_fetch_conjugations: parses valid JSON from LLM; returns None on bad JSON"
+    good_json = '{"verb":"nehmen","english":"to take","conjugations":{"ich":"nehme","du":"nimmst","er":"nimmt","wir":"nehmen","ihr":"nehmt","sie":"nehmen"}}'
+    with mock.patch("german_domain._call_llm", return_value=good_json):
+        result = _fetch_conjugations("nehmen")
+    with mock.patch("german_domain._call_llm", return_value="not json at all"):
+        bad = _fetch_conjugations("nehmen")
+    with mock.patch("german_domain._call_llm", return_value=None):
+        none_result = _fetch_conjugations("nehmen")
+    passed = (
+        result is not None and result.get("verb") == "nehmen" and
+        bad is None and none_result is None
+    )
+    report("D24", name, passed, f"good={result and result.get('verb')}, bad={bad}, none={none_result}")
+
+def test_D25():
+    name = "_fetch_phrases: parses valid JSON array; returns [] on bad JSON or None"
+    good_json = '[{"english":"I will take it","german":"Ich werde es nehmen"},{"english":"Take this","german":"Nehmen Sie das"}]'
+    with mock.patch("german_domain._call_llm", return_value=good_json):
+        result = _fetch_phrases("nehmen", "to take")
+    with mock.patch("german_domain._call_llm", return_value="garbage"):
+        bad = _fetch_phrases("nehmen", "to take")
+    with mock.patch("german_domain._call_llm", return_value=None):
+        none_result = _fetch_phrases("nehmen", "to take")
+    passed = len(result) == 2 and bad == [] and none_result == []
+    report("D25", name, passed, f"good_count={len(result)}, bad={bad}, none={none_result}")
+
+def test_D26():
+    name = "_write_drill_anki: friction items written to CSV; clean items skipped"
+    with tempfile.TemporaryDirectory() as tmp:
+        original = german_domain.GERMAN_DIR
+        fake_dir = Path(tmp)
+        (fake_dir / "anki").mkdir()
+        german_domain.GERMAN_DIR = fake_dir
+        try:
+            state = {
+                "items": [
+                    {"front": "I'll take it", "back": "Ich nehme es", "result": "needs-practice", "tags": "needs-practice Vienna phrase nehmen"},
+                    {"front": "clean item",   "back": "sauber",        "result": "drill-clean",    "tags": "drill-clean Vienna phrase nehmen"},
+                ]
+            }
+            written = _write_drill_anki(state)
+            csv_path = fake_dir / "anki" / "vienna_deck.csv"
+            content = csv_path.read_text()
+        finally:
+            german_domain.GERMAN_DIR = original
+    friction_in_csv = "I'll take it" in content
+    passed = written == 1 and friction_in_csv and "clean item" not in content
+    report("D26", name, passed, f"written={written}, csv_has_friction={friction_in_csv}",
+           expected="written=1", got=f"written={written}")
+
+def test_D27():
+    name = "_drill_completion_message: returns string with score and counts"
+    state = {
+        "score": 4, "total": 6,
+        "items": [
+            {"result": "drill-clean"},
+            {"result": "drill-reinforced"},
+            {"result": "needs-practice"},
+            {"result": "drill-clean"},
+        ]
+    }
+    with mock.patch("german_domain._write_drill_anki", return_value=0):
+        msg = _drill_completion_message(state, "✅ nehmen — nehme")
+    passed = (
+        "4/6" in msg and
+        "Clean: 2" in msg and
+        "Reinforced: 1" in msg and
+        "Needs practice: 1" in msg and
+        "again" in msg
+    )
+    report("D27", name, passed, repr(msg[:120]))
+
+
 # ─── Main runner ──────────────────────────────────────────────────────────────
 
 ALL_TESTS = [
     test_D01, test_D02, test_D03, test_D04, test_D05,
     test_D06, test_D07, test_D08, test_D09, test_D10,
     test_D11, test_D12, test_D13, test_D14, test_D15,
+    test_D16, test_D17, test_D18, test_D19, test_D20,
+    test_D21, test_D22, test_D23, test_D24, test_D25,
+    test_D26, test_D27,
 ]
 
 if __name__ == "__main__":

--- a/_NewDomains/language-german/test_german_domain.py
+++ b/_NewDomains/language-german/test_german_domain.py
@@ -1,0 +1,278 @@
+"""
+test_german_domain.py — Test suite for german_domain.py (Group A)
+
+Usage:
+    python3 test_german_domain.py          # run all tests
+    python3 test_german_domain.py --test 3 # run single test
+
+After each run, writes results to:
+    ../../_working/test_german_domain_results_YYYYMMDD.md
+"""
+
+import sys
+import argparse
+from pathlib import Path
+from datetime import datetime
+
+# Make german_domain importable from repo root
+REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from german_domain import (
+    _normalize_answer, _expand_contractions, _parse_spoken_id,
+    _lookup_verb, _all_verb_entries,
+    _item_tag, _drill_prompt, _l2_prompt,
+    _start_drill_state, _record_l1_person, _record_l2_item, _finalize_l1_items,
+    _resolve_keyword_intent, _spell_feedback,
+    _SESSION_RE, _DRILL_RE, _DRILL_LIST_RE,
+    _DRILL_CTL_RE, _PHRASE_CAPTURE_RE, _AGAIN_RE,
+    GERMAN_DIR, GERMAN_BASE,
+)
+
+# ─── Test runner ─────────────────────────────────────────────────────────────
+
+_results: list[dict] = []
+
+def report(test_num: str, name: str, passed: bool, detail: str = "") -> None:
+    status = "PASS" if passed else "FAIL"
+    label = f"Test {test_num} — {name}"
+    suffix = f": {detail}" if detail else ""
+    print(f"{label}: {status}{suffix}")
+    _results.append({"num": test_num, "name": name, "status": status, "detail": detail})
+
+# ─── Sample data ─────────────────────────────────────────────────────────────
+
+SAMPLE_POOL = {
+    "core": {
+        "verbs": [
+            {"verb": "nehmen", "english": "to take", "conjugations": {"ich": "nehme", "du": "nimmst", "er": "nimmt", "wir": "nehmen", "ihr": "nehmt", "sie": "nehmen"}},
+            {"verb": "gehen",  "english": "to go",   "conjugations": {"ich": "gehe",  "du": "gehst",  "er": "geht",  "wir": "gehen",  "ihr": "geht",   "sie": "gehen"}},
+        ]
+    },
+    "on_demand": {
+        "verbs": [
+            {"verb": "sagen",  "english": "to say",  "conjugations": {}},
+            {"verb": "nehmen", "english": "duplicate — should be skipped by core precedence", "conjugations": {}},
+        ]
+    }
+}
+
+SAMPLE_ENTRY = SAMPLE_POOL["core"]["verbs"][0]  # nehmen
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+def test_D01():
+    name = "_normalize_answer: lowercase, strip punctuation, collapse whitespace"
+    result = _normalize_answer("Ich BIN  müde!")
+    passed = result == "ich bin müde"
+    report("D01", name, passed, repr(result))
+
+def test_D02():
+    name = "_expand_contractions: im → in dem, ins → in das, no-op on unknown"
+    r1 = _expand_contractions("Ich gehe im Park.")
+    r2 = _expand_contractions("Er geht ins Café.")
+    r3 = _expand_contractions("Das ist schön.")
+    passed = (
+        "in dem" in r1 and
+        "in das" in r2 and
+        r3 == "Das ist schön."
+    )
+    report("D02", name, passed, f"im→{r1!r} / ins→{r2!r}")
+
+def test_D03():
+    name = "_parse_spoken_id: 'one' → '001', 'three' → '003', bare digit '5' → '005'"
+    r1 = _parse_spoken_id("one")
+    r2 = _parse_spoken_id("three")
+    r3 = _parse_spoken_id("5")
+    passed = r1 == "001" and r2 == "003" and r3 == "005"
+    report("D03", name, passed, f"one={r1}, three={r2}, 5={r3}")
+
+def test_D04():
+    name = "_lookup_verb: found in pool, not found returns None"
+    found = _lookup_verb(SAMPLE_POOL, "nehmen")
+    not_found = _lookup_verb(SAMPLE_POOL, "wissen")
+    passed = found is not None and found["verb"] == "nehmen" and not_found is None
+    report("D04", name, passed, f"found={found and found['verb']}, not_found={not_found}")
+
+def test_D05():
+    name = "_all_verb_entries: merges core + on_demand, core takes precedence (no nehmen duplicate)"
+    entries = _all_verb_entries(SAMPLE_POOL)
+    names = [e["verb"] for e in entries]
+    nehmen_count = names.count("nehmen")
+    sagen_present = "sagen" in names
+    passed = nehmen_count == 1 and sagen_present and len(entries) == 3
+    report("D05", name, passed, f"verbs={names}, nehmen_count={nehmen_count}")
+
+def test_D06():
+    name = "_item_tag: wrong=0→drill-clean, wrong=1→drill-reinforced, hint→needs-practice"
+    t1 = _item_tag(0, False, False)
+    t2 = _item_tag(1, False, False)
+    t3 = _item_tag(0, True,  False)
+    t4 = _item_tag(0, False, True)
+    t5 = _item_tag(2, False, False)
+    passed = (t1 == "drill-clean" and t2 == "drill-reinforced" and
+              t3 == "needs-practice" and t4 == "needs-practice" and
+              t5 == "needs-practice")
+    report("D06", name, passed, f"{t1}/{t2}/{t3}/{t4}/{t5}")
+
+def test_D07():
+    name = "_drill_prompt: contains verb, english, person, position"
+    state = _start_drill_state(SAMPLE_ENTRY)
+    prompt = _drill_prompt(state)
+    passed = (
+        "nehmen" in prompt and
+        "to take" in prompt and
+        "___?" in prompt and
+        "1/" in prompt
+    )
+    report("D07", name, passed, repr(prompt[:80]))
+
+def test_D08():
+    name = "_l2_prompt: contains position and 'How do you say'"
+    state = _start_drill_state(SAMPLE_ENTRY)
+    state["phrases"] = [{"english": "I'll take it", "german": "Ich nehme es"}]
+    state["queue"] = [0]
+    state["pos"] = 0
+    prompt = _l2_prompt(state)
+    passed = "How do you say" in prompt and "I'll take it" in prompt and "1/" in prompt
+    report("D08", name, passed, repr(prompt[:80]))
+
+def test_D09():
+    name = "_start_drill_state: all required keys present, initial values correct"
+    state = _start_drill_state(SAMPLE_ENTRY)
+    required = {"verb", "english", "conjugations", "queue", "pos", "current",
+                "score", "total", "retry", "items", "hint_used_current", "l1_worst_tag"}
+    missing = required - set(state.keys())
+    passed = (
+        not missing and
+        state["verb"] == "nehmen" and
+        state["pos"] == 0 and
+        state["score"] == 0 and
+        state["items"] == [] and
+        state["l1_worst_tag"] == "drill-clean" and
+        len(state["queue"]) == 6
+    )
+    report("D09", name, passed, f"missing={missing}, verb={state.get('verb')}, queue_len={len(state.get('queue', []))}")
+
+def test_D10():
+    name = "_record_l1_person: clean answer keeps drill-clean, wrong escalates l1_worst_tag"
+    state = _start_drill_state(SAMPLE_ENTRY)
+    _record_l1_person(state, wrong_count=0, auto_revealed=False)
+    after_clean = state["l1_worst_tag"]
+    _record_l1_person(state, wrong_count=1, auto_revealed=False)
+    after_wrong = state["l1_worst_tag"]
+    passed = after_clean == "drill-clean" and after_wrong == "drill-reinforced"
+    report("D10", name, passed, f"clean={after_clean}, wrong={after_wrong}")
+
+def test_D11():
+    name = "_record_l2_item: appends item, clears hint_used_current"
+    state = _start_drill_state(SAMPLE_ENTRY)
+    state["hint_used_current"] = True
+    phrase = {"english": "I'll take it", "german": "Ich nehme es"}
+    _record_l2_item(state, phrase, wrong_count=0, auto_revealed=False)
+    passed = (
+        len(state["items"]) == 1 and
+        state["items"][0]["front"] == "I'll take it" and
+        state["items"][0]["result"] == "needs-practice" and  # hint_used → needs-practice
+        state["hint_used_current"] == False
+    )
+    report("D11", name, passed, f"item={state['items'][0].get('result')}, hint_cleared={not state['hint_used_current']}")
+
+def test_D12():
+    name = "_finalize_l1_items: drill-clean produces no item; reinforced produces one Anki item"
+    state_clean = _start_drill_state(SAMPLE_ENTRY)
+    _finalize_l1_items(state_clean)
+    no_item = len(state_clean["items"]) == 0
+
+    state_wrong = _start_drill_state(SAMPLE_ENTRY)
+    state_wrong["l1_worst_tag"] = "drill-reinforced"
+    _finalize_l1_items(state_wrong)
+    has_item = len(state_wrong["items"]) == 1 and "nehmen" in state_wrong["items"][0]["front"]
+
+    passed = no_item and has_item
+    report("D12", name, passed, f"clean_items={len(state_clean['items'])}, wrong_items={len(state_wrong['items'])}")
+
+def test_D13():
+    name = "_resolve_keyword_intent: matches keyword, single word fires not, no match returns None"
+    kmap = {"Georg": {"trigger_words": ["Georg", "café"], "default_scenario": "coffee"}}
+    match = _resolve_keyword_intent("let's do Georg today", kmap)
+    no_match = _resolve_keyword_intent("let's do Maria today", kmap)
+    single = _resolve_keyword_intent("Georg", kmap)  # single word — should not fire
+    passed = (
+        match is not None and match[0] == "Georg" and
+        no_match is None and
+        single is None
+    )
+    report("D13", name, passed, f"match={match}, no_match={no_match}, single={single}")
+
+def test_D14():
+    name = "_spell_feedback: returns non-None for clear German misspelling"
+    # "nehmen" misspelled as "nehemn" — should get a suggestion
+    result = _spell_feedback("ich nehemn das")
+    # If spellchecker not installed, None is acceptable (library gracefully returns None)
+    passed = result is None or (isinstance(result, str) and len(result) > 0)
+    report("D14", name, passed, repr(result))
+
+def test_D15():
+    name = "Regex smoke: _SESSION_RE, _DRILL_RE, _DRILL_LIST_RE, _AGAIN_RE key patterns match"
+    session_ok = bool(_SESSION_RE.search("next german session please"))
+    drill_ok   = bool(_DRILL_RE.search("drill nehmen"))
+    list_ok    = bool(_DRILL_LIST_RE.search("drill list"))
+    again_ok   = bool(_AGAIN_RE.search("again"))
+    ctl_ok     = bool(_DRILL_CTL_RE.search("stop"))
+    phrase_ok  = bool(_PHRASE_CAPTURE_RE.search("save a phrase"))
+    passed = session_ok and drill_ok and list_ok and again_ok and ctl_ok and phrase_ok
+    report("D15", name, passed,
+           f"session={session_ok} drill={drill_ok} list={list_ok} again={again_ok} ctl={ctl_ok} phrase={phrase_ok}")
+
+# ─── Main runner ──────────────────────────────────────────────────────────────
+
+ALL_TESTS = [
+    test_D01, test_D02, test_D03, test_D04, test_D05,
+    test_D06, test_D07, test_D08, test_D09, test_D10,
+    test_D11, test_D12, test_D13, test_D14, test_D15,
+]
+
+def _write_results_md():
+    today = datetime.now().strftime("%Y%m%d")
+    out_path = REPO_ROOT / "_working" / f"test_german_domain_results_{today}.md"
+    passed = sum(1 for r in _results if r["status"] == "PASS")
+    total = len(_results)
+    lines = [
+        f"# german_domain.py — Test Results",
+        f"**Run:** {datetime.now().strftime('%Y-%m-%d %H:%M')}  ",
+        f"**Suite:** Group A (constants + pure functions)  ",
+        f"**Result:** {passed}/{total} passed",
+        "",
+        "| # | Test | Status | Detail |",
+        "|---|------|--------|--------|",
+    ]
+    for r in _results:
+        icon = "✅" if r["status"] == "PASS" else "❌"
+        detail = r["detail"].replace("|", "\\|")
+        lines.append(f"| {r['num']} | {r['name']} | {icon} {r['status']} | {detail} |")
+    out_path.write_text("\n".join(lines) + "\n")
+    print(f"\nResults written to: {out_path}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test", type=str, help="Run single test by number, e.g. D03")
+    args = parser.parse_args()
+
+    if args.test:
+        target = args.test.upper().lstrip("0") or "0"
+        run = [t for t in ALL_TESTS if t.__name__.upper().endswith(target)]
+        if not run:
+            print(f"No test matching '{args.test}'")
+            sys.exit(1)
+        for t in run:
+            t()
+    else:
+        for t in ALL_TESTS:
+            t()
+
+    passed = sum(1 for r in _results if r["status"] == "PASS")
+    total = len(_results)
+    print(f"\n{passed}/{total} tests passed.")
+    _write_results_md()
+    sys.exit(0 if passed == total else 1)

--- a/_working/build_note_group_a.md
+++ b/_working/build_note_group_a.md
@@ -1,0 +1,129 @@
+# Build Note: Group A Extraction — Constants and Pure Functions
+**Date:** 2026-05-19
+**Branch:** feat/german-domain-extraction
+**Commit:** cf592f3
+**Spec:** docs/GERMAN_HTML_BUILD_PLAN_v1.0.md — Step 1, Group A
+
+---
+
+## What Group A is
+
+Constants, data structures, and pure functions with no I/O, no async, no Telegram coupling.
+The safe first extraction: anything that fails will fail loudly at import time or in a pure
+unit test — no side effects, no live system impact.
+
+---
+
+## Step 0 gate (baseline before any extraction)
+
+- 49/49 existing tests passed on `main` before the branch was cut
+- Branch created: `feat/german-domain-extraction`
+- Baseline commit: `test: confirm 49-test baseline before extraction`
+
+---
+
+## What moved
+
+### Path constants
+
+| Constant | Value |
+|---|---|
+| `_BASE_DIR` | `Path(__file__).parent` (repo root) |
+| `GERMAN_BASE` | `_BASE_DIR / "_NewDomains" / "language-german"` |
+| `GERMAN_DIR` | `GERMAN_BASE / "language" / "german"` |
+| `VENV_PYTHON` | `_BASE_DIR / "venv" / "bin" / "python3"` |
+| `ROBERT_CHAT_ID` | `8379221702` |
+
+### Regex patterns (all compiled at module level)
+
+`_WRITING_RE`, `_SESSION_RE`, `_CONJUGATE_RE`, `_DRILL_RE`, `_DRILL_L2_RE`,
+`_DRILL_CTL_RE`, `_DRILL_AGAIN_RE`, `_DRILL_LIST_RE`, `_DRILL_MORE_RE`,
+`_SKIP_LESSON_RE`, `_AGAIN_RE`, `_PHRASE_CAPTURE_RE`, `_PHRASE_PRACTICE_VOICE_RE`,
+`_PHRASE_LIST_VOICE_RE`, `_PHRASE_LIST_MORE_VOICE_RE`
+
+### Data structures
+
+| Name | Type | Notes |
+|---|---|---|
+| `_SPOKEN_NUMBERS` | dict | maps spoken word → zero-padded string ("one" → "001") |
+| `_LLM_PROVIDERS` | list of dicts | ordered provider config: xai → anthropic → ollama |
+| `_DE_CONTRACTIONS` | dict | German contraction expansions (im → in dem, ins → in das, etc.) |
+| `_DE_CONTRACTION_RE` | compiled regex | built from `_DE_CONTRACTIONS` keys |
+| `_DRILL_PERSONS` | list | six grammatical persons for conjugation drill |
+| `_PERSONS_DISPLAY` | list | display forms matching `_DRILL_PERSONS` |
+| `_PERSONS_POOL` | list | pool forms for conjugation lookup |
+
+### Pure functions (14 total)
+
+| Function | What it does |
+|---|---|
+| `_resolve_keyword_intent` | maps user text to (persona, scenario) via keyword_map dict |
+| `_parse_spoken_id` | converts spoken number word or digit string → zero-padded ID |
+| `_all_verb_entries` | merges core + on_demand verb pools; core takes precedence on duplicates |
+| `_lookup_verb` | finds verb entry in pool by name; returns None if not found |
+| `_expand_contractions` | replaces German contractions in text using `_DE_CONTRACTIONS` |
+| `_normalize_answer` | lowercase, strip punctuation, collapse whitespace, expand contractions |
+| `_spell_feedback` | heuristic spell-check hint for a single German word |
+| `_item_tag` | assigns drill result tag based on wrong count and hint usage |
+| `_drill_prompt` | builds Level 1 (conjugation fill-in) prompt string |
+| `_l2_prompt` | builds Level 2 (translation) prompt string |
+| `_start_drill_state` | initializes drill state dict for a verb entry |
+| `_record_l2_item` | appends a Level 2 result item to drill state |
+| `_record_l1_person` | tracks worst Level 1 tag in drill state |
+| `_finalize_l1_items` | converts worst L1 tag into one Anki item if friction occurred |
+
+---
+
+## Key design decisions
+
+**New file vs. appending to existing:** `german_domain.py` created as a new file at repo root.
+This is where both `telegram_bot.py` and the planned `html_server.py` can import from without
+directory coupling.
+
+**Module docstring signals intent:** The docstring at the top of `german_domain.py` explicitly
+states that both Telegram bots route to the same entrypoint, and that Group A is the boundary
+definition. This is the OpenClaw note #3 from the build plan.
+
+**`_LLM_PROVIDERS` as data, not code:** Provider configuration (model names, types) moved as a
+data structure rather than a class or factory. Keeps the config readable and makes it easy to
+add providers or reorder fallback without touching function logic.
+
+**Regex compiled at module level:** All patterns compiled once at import time. No construction
+cost at call time. Consistent with the existing `telegram_bot.py` pattern.
+
+**`telegram_bot.py` import block is explicit:** All imported names are listed individually (not
+`import *`). This makes the dependency surface visible and prevents accidental name shadowing.
+
+---
+
+## Tests added: D01–D15
+
+| # | Function | What it tests |
+|---|---|---|
+| D01 | `_normalize_answer` | lowercase, strip punctuation, collapse whitespace |
+| D02 | `_expand_contractions` | im → in dem, ins → in das, no-op on unknown |
+| D03 | `_parse_spoken_id` | spoken words and bare digits → zero-padded strings |
+| D04 | `_lookup_verb` | found in pool, not found returns None |
+| D05 | `_all_verb_entries` | merges core + on_demand; core precedence on duplicate |
+| D06 | `_item_tag` | wrong=0→clean, wrong=1→reinforced, hint→needs-practice |
+| D07 | `_drill_prompt` | contains verb, english, person, position |
+| D08 | `_l2_prompt` | contains position and "How do you say" |
+| D09 | `_start_drill_state` | all required keys present, initial values correct |
+| D10 | `_record_l1_person` | clean keeps drill-clean; wrong escalates l1_worst_tag |
+| D11 | `_record_l2_item` | appends item, clears hint_used_current |
+| D12 | `_finalize_l1_items` | drill-clean → no item; reinforced → one Anki item |
+| D13 | `_resolve_keyword_intent` | keyword match, single-word no-fire, no match → None |
+| D14 | `_spell_feedback` | returns hint for clear misspelling |
+| D15 | Regex smoke | _SESSION_RE, _DRILL_RE, _DRILL_LIST_RE, _AGAIN_RE match key patterns |
+
+All 15 tests use sample data only — no file I/O, no mocking needed.
+
+---
+
+## Gate results
+
+| Check | Result |
+|---|---|
+| `venv/bin/python3 _NewDomains/language-german/run_tests.py` | 49/49 pass |
+| `venv/bin/python3 _NewDomains/language-german/test_german_domain.py` | 15/15 pass |
+| `venv/bin/python3 -c "import telegram_bot"` | clean import |

--- a/_working/build_note_group_b.md
+++ b/_working/build_note_group_b.md
@@ -1,0 +1,110 @@
+# Build Note: Group B Extraction — Domain I/O and LLM Functions
+**Date:** 2026-05-19
+**Branch:** feat/german-domain-extraction
+**Commit:** 559188d
+**Spec:** docs/GERMAN_HTML_BUILD_PLAN_v1.0.md — Step 1, Group B
+
+---
+
+## What Group B is
+
+Functions that have file I/O, subprocess calls, or external LLM API calls — but no async, no
+Telegram coupling. After Group B, `german_domain.py` contains all non-async domain logic.
+Group C (async + callback pattern) follows.
+
+---
+
+## Path constants moved
+
+These are used exclusively by Group B functions and moved with them:
+
+| Constant | Value |
+|---|---|
+| `_PHRASEBOOK_FILE` | `GERMAN_DIR / "config" / "phrasebook.json"` |
+| `_DRILL_STATE_FILE` | `_BASE_DIR / "_active_drill_state.json"` |
+| `_DRILL_LIST_STATE_FILE` | `_BASE_DIR / "_drill_list_state.json"` |
+
+**Not moved:** `_active_drills`, `_last_drills`, `_drill_list_state` runtime dicts — these are
+Telegram session state, not domain logic. They stay in `telegram_bot.py`.
+
+---
+
+## Functions extracted (14 total)
+
+| Function | Dependencies | Notes |
+|---|---|---|
+| `_load_keyword_map_bot` | `json`, `GERMAN_DIR` | reads keyword_map.json |
+| `_last_session_persona` | `json`, `GERMAN_DIR` | reads latest session JSON, returns persona name |
+| `_run` | `subprocess` | general subprocess wrapper, returns (stdout, stderr, returncode) |
+| `_german_agent_mode` | `json`, `GERMAN_DIR` | reads sync_config.json, returns "direct" or mode string |
+| `_phrase_next_id` | none | pure — missed in Group A, moved here; global sequence, never resets per day |
+| `_load_drill_pool` | `json`, `GERMAN_DIR` | reads drill_pool.json; returns {} on missing |
+| `_save_drill_pool` | `json`, `GERMAN_DIR` | writes drill_pool.json |
+| `_load_phrasebook` | `json`, `_PHRASEBOOK_FILE` | reads phrasebook.json; returns {"phrases": []} on missing |
+| `_save_phrasebook` | `json`, `_PHRASEBOOK_FILE` | writes phrasebook.json |
+| `_call_llm` | `keyring`, `openai`, `anthropic` | tries xai → anthropic → ollama in order; returns None on all fail |
+| `_fetch_conjugations` | `_call_llm`, `json` | LLM → JSON parse; returns None on bad JSON or None from LLM |
+| `_fetch_phrases` | `_call_llm`, `json` | LLM → JSON array; returns [] on bad JSON or None from LLM |
+| `_write_drill_anki` | `csv`, `GERMAN_DIR` | appends friction items to vienna_deck.csv; skips clean items and duplicates |
+| `_drill_completion_message` | `_write_drill_anki` | builds completion string with score/counts; calls _write_drill_anki as side effect |
+
+**Not in Group B** (these mutate Telegram session state dicts):
+- `_save_drill_list_state` / `_load_drill_list_state` — mutate `_drill_list_state`
+- `_save_drill_state` / `_load_drill_state` — mutate `_active_drills`
+
+---
+
+## Key design decisions
+
+**keyring inside the function body:** `keyring` is imported as `import keyring as _keyring` inside
+`_call_llm`, not at module level. Reason: `german_domain.py` must be importable in environments
+where keyring is not installed (e.g. system Python during testing). Moving the import inside the
+function means the module loads cleanly; keyring is only required when `_call_llm` is actually
+called.
+
+**_phrase_next_id classification:** This is a pure function (no I/O) that was missed in Group A.
+It was pulled in Group B rather than opening a new micro-commit. The global-sequence design (IDs
+never reset per day) was already in production from a previous bug fix (2ae4abd).
+
+**Runtime state dicts stay in telegram_bot.py:** `_active_drills`, `_last_drills`, `_drill_list_state`
+are Telegram polling-session state — they track live user interactions and are not domain logic.
+Only the FILE PATH constants (`_DRILL_STATE_FILE`, `_DRILL_LIST_STATE_FILE`) move, since the
+save/load functions that use them are moving.
+
+---
+
+## Tests added: D16–D27
+
+| # | Function | What it tests | Approach |
+|---|---|---|---|
+| D16 | `_phrase_next_id` | global max sequence, first ID, date prefix | pure — no mocking |
+| D17 | `_run` | returns (stdout, stderr, returncode) tuple | calls `echo hello` |
+| D18 | `_load_drill_pool` | returns `{}` when file missing; loads dict when present | tempdir |
+| D19 | `_save_drill_pool` + `_load_drill_pool` | round-trip preserves data | tempdir |
+| D20 | `_load_phrasebook` | returns `{"phrases": []}` when missing; loads correctly | tempdir |
+| D21 | `_save_phrasebook` + `_load_phrasebook` | round-trip preserves data | tempdir |
+| D22 | `_load_keyword_map_bot` | returns `{}` when missing; loads dict when present | tempdir |
+| D23 | `_call_llm` empty provider list | returns `None` when no providers configured | patches `_LLM_PROVIDERS` to `[]` |
+| D24 | `_fetch_conjugations` | parses valid JSON; returns None on bad JSON or LLM None | patches `_call_llm` |
+| D25 | `_fetch_phrases` | parses valid JSON array; returns `[]` on bad JSON or LLM None | patches `_call_llm` |
+| D26 | `_write_drill_anki` | friction written to CSV; clean items skipped | tempdir + patches `GERMAN_DIR` |
+| D27 | `_drill_completion_message` | returns string with score and counts | patches `_write_drill_anki` |
+
+**Mocking pattern:** stdlib `unittest.mock` only — no new test dependencies.
+- File I/O: `tempfile.TemporaryDirectory()` + monkeypatch `german_domain.GERMAN_DIR`
+- LLM: `mock.patch("german_domain._call_llm", return_value=...)`
+- D23 note: originally patched `keyring.get_password`, but Ollama (running locally) bypasses keyring.
+  Switched to patching `_LLM_PROVIDERS` to `[]` — tests the exhaustion path directly.
+
+**Test runner:** `venv/bin/python3` required (not bare `python3`) — keyring not in system Python.
+
+---
+
+## Gate results
+
+| Check | Result |
+|---|---|
+| `venv/bin/python3 _NewDomains/language-german/run_tests.py` | 49/49 pass |
+| `venv/bin/python3 _NewDomains/language-german/test_german_domain.py` | 27/27 pass |
+| `venv/bin/python3 -c "import telegram_bot"` | clean import |
+| `telegram_bot._call_llm is german_domain._call_llm` | True |

--- a/_working/build_note_group_c.md
+++ b/_working/build_note_group_c.md
@@ -1,0 +1,117 @@
+# Build Note: Group C Extraction — Async-Free Resolvers with Callback Pattern
+**Date:** 2026-05-19
+**Branch:** feat/german-domain-extraction
+**Spec:** docs/GERMAN_HTML_BUILD_PLAN_v1.0.md — Step 1, Group C
+
+---
+
+## What Group C is
+
+Async functions that make mid-execution `reply_text` Telegram calls during processing.
+The extraction converts them to plain (non-async) functions and replaces the Telegram
+call with an optional `progress_cb` parameter — keeping `german_domain.py` free of async
+and Telegram coupling.
+
+---
+
+## Scope boundary
+
+Exploration found ~25 async handlers in telegram_bot.py that use `reply_text` mid-execution
+(drill loop, phrase library, session handlers). Group C extracts only three, per spec:
+- `_resolve_verb`
+- `_resolve_phrases`
+- `_resolve_drill_verb`
+
+The remaining handlers are not domain logic — they are Telegram-specific response flows.
+Future refactor if needed.
+
+---
+
+## Callback signature
+
+```python
+progress_cb: callable | None = None
+```
+
+The domain functions are plain `def` (not async). The callback is called synchronously:
+```python
+if progress_cb:
+    progress_cb("message text")
+```
+
+In telegram_bot.py, the adapter wraps it as an async function:
+```python
+async def _cb(msg): await update.message.reply_text(msg)
+entry = _resolve_verb(verb_lower, progress_cb=_cb)  # NOT awaited
+```
+
+This design keeps `german_domain.py` completely free of async. The `_cb` definition
+lives in the Telegram handler — one per handler that calls a Group C function.
+
+---
+
+## Functions extracted (3 total)
+
+### `_resolve_verb(verb_lower: str, progress_cb=None) -> dict | None`
+- Looks up verb in drill pool; if missing, calls `_fetch_conjugations` and caches result
+- progress_cb called: "Looking up '{verb}'…" before LLM call; error message on failure
+- Internal call from `_resolve_drill_verb` threads the callback through
+
+### `_resolve_phrases(entry: dict, progress_cb=None) -> list`
+- Returns cached phrases from entry; if missing, calls `_fetch_phrases` and caches in drill_pool
+- progress_cb called: "Generating phrases for {verb}…" before LLM call; error on empty result
+
+### `_resolve_drill_verb(target_lower: str, progress_cb=None) -> dict | None`
+- Extracts verb from drill trigger text (direct match, scene keyword, or LLM lookup)
+- progress_cb called when a scene keyword resolves to a specific verb
+- Falls back to `_resolve_verb(word, progress_cb=progress_cb)` — callback threaded through
+
+---
+
+## Call sites updated in telegram_bot.py (4 total)
+
+| Handler | Old | New |
+|---|---|---|
+| `_handle_conjugate` | `await _resolve_verb(update, verb.lower())` | `_resolve_verb(verb.lower(), progress_cb=_cb)` |
+| `_handle_drill_l1_start` | `await _resolve_drill_verb(update, target_lower)` | `_resolve_drill_verb(target_lower, progress_cb=_cb)` |
+| `_handle_drill_l2_start` | `await _resolve_drill_verb(update, target_lower)` | `_resolve_drill_verb(target_lower, progress_cb=_cb)` |
+| `_handle_drill_l2_start` | `await _resolve_phrases(update, entry)` | `_resolve_phrases(entry, progress_cb=_cb)` |
+
+Each handler defines `async def _cb(msg): await update.message.reply_text(msg)` once and
+reuses it for all Group C calls within that handler.
+
+---
+
+## Also fixed: shadowing local redefinitions
+
+During Group B, `_DRILL_STATE_FILE` and `_DRILL_LIST_STATE_FILE` were added to the import
+block but the old local definitions at telegram_bot.py lines 941–942 were not removed.
+They shadowed the imports with identical values (same path). Removed in this commit —
+now the imported values from german_domain are authoritative.
+
+---
+
+## Tests added: D28–D32
+
+| # | Function | What it tests | Approach |
+|---|---|---|---|
+| D28 | `_resolve_verb` | returns entry from pool; progress_cb=None doesn't raise | patches `_load_drill_pool` |
+| D29 | `_resolve_verb` | progress_cb called with "Looking up" when verb not in pool | mock callback + patches |
+| D30 | `_resolve_phrases` | returns cached phrases; progress_cb=None doesn't raise | pure call |
+| D31 | `_resolve_drill_verb` | returns entry for known verb; progress_cb=None | patches `_load_drill_pool` |
+| D32 | `_resolve_drill_verb` | callback fired when scene keyword resolves to verb | patches `_load_drill_pool` |
+
+No asyncio.run() needed — functions are plain def.
+
+---
+
+## Gate results
+
+| Check | Result |
+|---|---|
+| `venv/bin/python3 _NewDomains/language-german/run_tests.py` | 49/49 pass |
+| `venv/bin/python3 _NewDomains/language-german/test_german_domain.py` | 32/32 pass |
+| `venv/bin/python3 -c "import telegram_bot"` | clean import |
+| `telegram_bot._resolve_verb is german_domain._resolve_verb` | True |
+| `telegram_bot._resolve_phrases is german_domain._resolve_phrases` | True |
+| `telegram_bot._resolve_drill_verb is german_domain._resolve_drill_verb` | True |

--- a/_working/build_note_group_d.md
+++ b/_working/build_note_group_d.md
@@ -1,0 +1,91 @@
+# Build Note: Group D — Wire Adapters (Adapter Boundary Verification)
+**Date:** 2026-05-19
+**Branch:** feat/german-domain-extraction
+**Spec:** docs/GERMAN_HTML_BUILD_PLAN_v1.0.md — Step 1, Group D
+
+---
+
+## What Group D is
+
+Verification that the adapter boundary is clean after Groups A–C. No new extraction —
+Group D confirms that telegram_bot.py now contains only:
+- Message routing (handler dispatch)
+- Whisper voice transcription
+- Telegram formatting helpers
+- Callback delivery (reply_text, send_message)
+- Session state dicts (Telegram polling state, not domain logic)
+
+And that `german_domain.py` contains all domain logic.
+
+---
+
+## Import block — final state
+
+```python
+from german_domain import (
+    # Group A — constants and pure functions
+    ROBERT_CHAT_ID, GERMAN_BASE, GERMAN_DIR, VENV_PYTHON,
+    _WRITING_RE, _SESSION_RE, _CONJUGATE_RE,
+    _DRILL_RE, _DRILL_L2_RE, _DRILL_CTL_RE, _DRILL_AGAIN_RE,
+    _DRILL_LIST_RE, _DRILL_MORE_RE, _SKIP_LESSON_RE, _AGAIN_RE,
+    _PHRASE_CAPTURE_RE, _PHRASE_PRACTICE_VOICE_RE,
+    _PHRASE_LIST_VOICE_RE, _PHRASE_LIST_MORE_VOICE_RE,
+    _SPOKEN_NUMBERS, _LLM_PROVIDERS,
+    _DE_CONTRACTIONS, _DE_CONTRACTION_RE,
+    _DRILL_PERSONS, _PERSONS_DISPLAY, _PERSONS_POOL,
+    _resolve_keyword_intent, _parse_spoken_id,
+    _all_verb_entries, _lookup_verb,
+    _expand_contractions, _normalize_answer, _spell_feedback,
+    _item_tag, _drill_prompt, _l2_prompt,
+    _start_drill_state, _record_l2_item, _record_l1_person, _finalize_l1_items,
+    # Group B — I/O and LLM functions
+    _PHRASEBOOK_FILE, _DRILL_STATE_FILE, _DRILL_LIST_STATE_FILE,
+    _load_keyword_map_bot, _last_session_persona, _run, _german_agent_mode,
+    _phrase_next_id, _load_drill_pool, _save_drill_pool,
+    _load_phrasebook, _save_phrasebook,
+    _call_llm, _fetch_conjugations, _fetch_phrases,
+    _write_drill_anki, _drill_completion_message,
+    # Group C — async-free resolvers with callback pattern
+    _resolve_verb, _resolve_phrases, _resolve_drill_verb,
+)
+```
+
+---
+
+## Adapter boundary analysis
+
+### Stays in telegram_bot.py (correct)
+
+| Item | Reason |
+|---|---|
+| `_arun` | Async wrapper for `_run` — uses `loop.run_in_executor` to keep event loop free. Telegram adapter layer. |
+| `_active_drills`, `_last_drills`, `_drill_list_state` | Polling session state dicts — track live user interactions, not domain logic |
+| `_save_drill_state`, `_load_drill_state` | Mutate `_active_drills` (Telegram session dict) |
+| `_save_drill_list_state`, `_load_drill_list_state` | Mutate `_drill_list_state` (Telegram session dict) |
+| All `async def _handle_*` functions | Telegram message handlers — routing + reply_text delivery |
+| `transcribe_voice`, `classify_voice` | Whisper transcription, Telegram-specific audio pipeline |
+| `send_message`, `send_briefing`, `send_article` | Telegram formatting + delivery |
+| `button_callback` | Telegram inline keyboard callback handling |
+
+### What's NOT in scope for future extraction
+
+~25 async handlers (drill loop, phrase library, session flow) remain in telegram_bot.py.
+They use `reply_text` mid-execution but are orchestration logic tied to Telegram state
+(active_drills, phrase_practice, etc.). Extracting them would require either:
+- Moving all the session state dicts too, or
+- A much larger async context + callback design
+
+Deferred. Not a v1.0 requirement.
+
+---
+
+## Gate results
+
+| Check | Result |
+|---|---|
+| `venv/bin/python3 _NewDomains/language-german/run_tests.py` | 49/49 pass |
+| `venv/bin/python3 _NewDomains/language-german/test_german_domain.py` | 32/32 pass |
+| `venv/bin/python3 -c "import telegram_bot"` | clean import |
+| All Group C identity checks | True |
+| No `await _resolve_verb/phrases/drill_verb` remaining | Confirmed (grep clean) |
+| No shadowing local path constant redefinitions | Confirmed — removed in Group C commit |

--- a/german_domain.py
+++ b/german_domain.py
@@ -5,6 +5,8 @@ Both telegram_bot.py and html_server.py import from here.
 Both @minimoi_cmd_bot and @minimoi_agent_bot route to the same Python entrypoint.
 
 Group A: constants, data structures, pure functions (no I/O, no async, no Telegram).
+Group B: file I/O, subprocess, LLM callers (no async, no Telegram).
+Group C: resolver functions — sync, with optional progress_cb for mid-execution messages.
 """
 
 import re
@@ -510,3 +512,70 @@ def _fetch_phrases(verb: str, english: str) -> list:
     except Exception as e:
         print(f"⚠️  Failed to parse phrases JSON for '{verb}': {e}\nRaw: {raw[:100]}")
         return []
+
+
+# ─── Async-free resolvers (Group C) ───────────────────────────────────────────
+
+def _resolve_verb(verb_lower: str, progress_cb=None) -> dict | None:
+    """Find verb in pool or fetch via LLM and cache. Calls progress_cb(msg) for progress."""
+    pool = _load_drill_pool()
+    entry = _lookup_verb(pool, verb_lower)
+    if entry:
+        return entry
+    if progress_cb:
+        progress_cb(f"Looking up '{verb_lower}'…")
+    entry = _fetch_conjugations(verb_lower)
+    if not entry:
+        if progress_cb:
+            progress_cb(f"Couldn't look up '{verb_lower}' — check spelling.")
+        return None
+    on_demand_verbs = pool.setdefault("on_demand", {}).setdefault("verbs", [])
+    on_demand_verbs.append(entry)
+    _save_drill_pool(pool)
+    return entry
+
+
+def _resolve_phrases(entry: dict, progress_cb=None) -> list:
+    """Return cached phrases for a verb entry, or fetch+cache via LLM."""
+    if entry.get("phrases"):
+        return entry["phrases"]
+    if progress_cb:
+        progress_cb(f"Generating phrases for {entry['verb']}…")
+    phrases = _fetch_phrases(entry["verb"], entry.get("english", ""))
+    if not phrases:
+        if progress_cb:
+            progress_cb(f"Couldn't generate phrases for '{entry['verb']}'.")
+        return []
+    pool = _load_drill_pool()
+    for section in (pool.get("core", {}).get("verbs", []), pool.get("on_demand", {}).get("verbs", [])):
+        for v in section:
+            if isinstance(v, dict) and v.get("verb", "").lower() == entry["verb"].lower():
+                v["phrases"] = phrases
+                break
+    _save_drill_pool(pool)
+    entry["phrases"] = phrases
+    return phrases
+
+
+def _resolve_drill_verb(target_lower: str, progress_cb=None) -> dict | None:
+    """Extract verb from trigger text, look up or fetch. Returns entry or None."""
+    pool = _load_drill_pool()
+    all_verbs = _all_verb_entries(pool)
+    entry = next((v for v in all_verbs if v["verb"].lower() in target_lower), None)
+    if entry:
+        return entry
+    stop_words = {"drill", "german", "mode", "start", "verb", "my", "errors", "mistakes",
+                  "level", "translate", "l2", "phrase", "phrases"}
+    words = [w for w in target_lower.split() if w not in stop_words and len(w) > 3 and not w.isdigit()]
+    if words:
+        word = words[0]
+        all_scenes = {s for v in all_verbs for s in v.get("scenes", [])}
+        if word in all_scenes:
+            scene_verbs = [v for v in all_verbs if word in v.get("scenes", [])]
+            if scene_verbs:
+                chosen = random.choice(scene_verbs)
+                if progress_cb:
+                    progress_cb(f"'{word}' is a scene, not a verb — picking {chosen['verb']} ({chosen.get('english', '')}) from that scene.")
+                return chosen
+        return _resolve_verb(word, progress_cb=progress_cb)
+    return random.choice(all_verbs) if all_verbs else None

--- a/german_domain.py
+++ b/german_domain.py
@@ -1,0 +1,273 @@
+"""
+German language domain — pure logic layer.
+
+Both telegram_bot.py and html_server.py import from here.
+Both @minimoi_cmd_bot and @minimoi_agent_bot route to the same Python entrypoint.
+
+Group A: constants, data structures, pure functions (no I/O, no async, no Telegram).
+"""
+
+import re
+import random
+from pathlib import Path
+
+# ─── Paths ────────────────────────────────────────────────────────────────────
+
+_BASE_DIR = Path(__file__).parent
+GERMAN_BASE = _BASE_DIR / "_NewDomains" / "language-german"
+GERMAN_DIR  = GERMAN_BASE / "language" / "german"
+VENV_PYTHON = _BASE_DIR / "venv" / "bin" / "python3"
+ROBERT_CHAT_ID = 8379221702
+
+# ─── Session / intent patterns ────────────────────────────────────────────────
+
+_WRITING_RE = re.compile(
+    r"(writing session|written session|"
+    r"session.{0,20}writing|writing.{0,20}session|"
+    r"next.{0,20}german.{0,20}writing|german.{0,20}writing)",
+    re.I,
+)
+_SESSION_RE = re.compile(
+    r"(pull today.?s german session|what.?s my german session|"
+    r"give me today.?s german prompt|german session please|"
+    r"german session today|today.?s german session|"
+    r"german session|session german|next session|next lesson|"
+    r"start.{0,30}german|start.{0,30}session.{0,30}german|"
+    r"let.{0,10}s.{0,10}german)",
+    re.I,
+)
+_CONJUGATE_RE = re.compile(r'\bconjugate\s+(\w+)\b', re.I)
+_DRILL_RE = re.compile(
+    r'(german\s+drill|drill\s+german|drill\s+mode|start\s+drill|drill\s+(?:level\s*2|l2|translate|verb|noun|word|vocab|my\s+mistakes|errors?|\d+\s+[a-zäöüß]{3,}|[a-zäöüß]{3,}))',
+    re.I,
+)
+_DRILL_L2_RE = re.compile(r'\b(?:level\s*2|l2|translate|phrases?|2)\b', re.I)
+_DRILL_CTL_RE = re.compile(r'\b(?:end(?:\s+drill)?|done|stop|quit|enough)\b', re.I)
+_DRILL_AGAIN_RE = re.compile(r'\b(?:again|repeat|once more|one more)\b', re.I)
+_DRILL_LIST_RE = re.compile(r'\b(?:drill\s+(?:\w+\s+)?list|list\s+(?:drills?|verbs?)|verbs?\s+list|show\s+verbs?|what\s+verbs?)\b', re.I)
+_DRILL_MORE_RE = re.compile(r'\b(?:more|next)\b', re.I)
+_SKIP_LESSON_RE = re.compile(
+    r'\b(?:skip\s+(?:lesson|session|this\s+one)|next\s+one|different\s+scene)\b',
+    re.I,
+)
+_AGAIN_RE = re.compile(
+    r"\b(again|one more|repeat|same (session|persona|scenario)|do it again)\b",
+    re.I,
+)
+
+# ─── Phrase patterns ──────────────────────────────────────────────────────────
+
+_PHRASE_CAPTURE_RE = re.compile(
+    r'\b(?:save\s+(?:a\s+)?phrase|capture\s+(?:this|a\s+phrase|phrase)|'
+    r'add?\s+(?:a\s+)?phrase|phrase\s+(?:add|capture|merken|speichern)|'
+    r'new\s+phrase|start\s+phrase\s+capture|neue\s+phrase|das\s+merken)\b',
+    re.I
+)
+_PHRASE_PRACTICE_VOICE_RE = re.compile(
+    r'\b(?:phra?se\s+practice|practice\s+(?:a\s+)?phra?se|phrase\s+üben)\b', re.I
+)
+_PHRASE_LIST_VOICE_RE = re.compile(
+    r'\b(?:phrase\s+list|list\s+(?:my\s+)?phrases?|show\s+(?:my\s+)?phrases?|my\s+phrases?)\b', re.I
+)
+_PHRASE_LIST_MORE_VOICE_RE = re.compile(
+    r'\b(?:phrase\s+more|more\s+phrases?|next\s+phrases?)\b', re.I
+)
+
+_SPOKEN_NUMBERS = {
+    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
+    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
+}
+
+# ─── LLM provider list ────────────────────────────────────────────────────────
+
+_LLM_PROVIDERS = [
+    {"name": "grok-mini",    "type": "xai",       "model": "grok-3-mini"},
+    {"name": "claude-haiku", "type": "anthropic",  "model": "claude-haiku-4-5-20251001"},
+    {"name": "ollama-gemma", "type": "ollama",     "model": "gemma3:1b"},
+]
+
+# ─── German contraction expansion ────────────────────────────────────────────
+
+_DE_CONTRACTIONS = {
+    "beim": "bei dem",
+    "im":   "in dem",
+    "am":   "an dem",
+    "vom":  "von dem",
+    "zum":  "zu dem",
+    "zur":  "zu der",
+    "ans":  "an das",
+    "ins":  "in das",
+    "aufs": "auf das",
+    "ums":  "um das",
+}
+_DE_CONTRACTION_RE = re.compile(
+    r'\b(' + '|'.join(re.escape(k) for k in _DE_CONTRACTIONS) + r')\b', re.IGNORECASE
+)
+
+# ─── Drill constants ──────────────────────────────────────────────────────────
+
+_DRILL_PERSONS   = ["ich", "du", "er", "wir", "ihr", "sie"]
+_PERSONS_DISPLAY = ["ich", "du", "er/sie/es", "wir", "ihr", "sie/Sie"]
+_PERSONS_POOL    = ["ich", "du", "er",         "wir", "ihr", "sie"]
+
+# ─── Pure functions ───────────────────────────────────────────────────────────
+
+def _resolve_keyword_intent(text: str, keyword_map: dict) -> tuple[str, str] | None:
+    """
+    Match trigger words from keyword_map against text.
+    Returns (persona_name, scenario) or None.
+
+    Safety rule: a lone trigger word with no surrounding context does not fire.
+    The message must have >=2 words OR contain 'german'/'session' alongside the keyword.
+    """
+    if not keyword_map:
+        return None
+    words = text.lower().split()
+    if len(words) < 2:
+        return None
+    for persona_name, data in keyword_map.items():
+        for trigger in data.get("trigger_words", []):
+            if trigger.lower() in text.lower():
+                return (persona_name, data.get("default_scenario", ""))
+    return None
+
+
+def _parse_spoken_id(text: str) -> str:
+    """Convert spoken phrase id to zero-padded string: 'one' → '001', '3' → '003'."""
+    t = re.sub(r'^number\s+', '', text.strip().strip(".,!? "), flags=re.I).strip()
+    m = re.search(r'\d+', t)
+    if m:
+        return f"{int(m.group()):03d}"
+    word = t.lower().strip(".,")
+    return f"{_SPOKEN_NUMBERS[word]:03d}" if word in _SPOKEN_NUMBERS else t
+
+
+def _all_verb_entries(pool: dict) -> list:
+    """Return all verb entries from core + on_demand, core takes precedence."""
+    core = [v for v in pool.get("core", {}).get("verbs", []) if isinstance(v, dict) and "verb" in v]
+    on_demand = [v for v in pool.get("on_demand", {}).get("verbs", []) if isinstance(v, dict) and "verb" in v]
+    core_names = {v["verb"].lower() for v in core}
+    return core + [v for v in on_demand if v["verb"].lower() not in core_names]
+
+
+def _lookup_verb(pool: dict, verb_lower: str) -> dict | None:
+    return next((v for v in _all_verb_entries(pool) if v["verb"].lower() == verb_lower), None)
+
+
+def _expand_contractions(text: str) -> str:
+    """Expand German preposition+article contractions to canonical long form."""
+    return _DE_CONTRACTION_RE.sub(lambda m: _DE_CONTRACTIONS[m.group(0).lower()], text)
+
+
+def _normalize_answer(text: str) -> str:
+    """Lowercase, strip punctuation, expand contractions, collapse whitespace."""
+    text = text.lower().strip()
+    text = re.sub(r'[^\w\s]', ' ', text)
+    text = _expand_contractions(text)
+    return " ".join(text.split())
+
+
+def _spell_feedback(normalized_answer: str, expected: str = "") -> str | None:
+    """Return feedback for misspelled German words. Input must already be normalized (no punctuation, lowercase).
+    If expected is given, only suggest corrections that appear in the expected answer."""
+    try:
+        from spellchecker import SpellChecker
+        from difflib import SequenceMatcher
+        checker = SpellChecker(language="de")
+        expected_words = set(expected.split()) if expected else set()
+        words = [w for w in normalized_answer.split() if len(w) >= 3]
+        unknown = checker.unknown(words)
+        if not unknown:
+            return None
+        parts = []
+        for w in unknown:
+            candidates = checker.candidates(w) or set()
+            best = max(candidates, key=lambda c: SequenceMatcher(None, w, c).ratio(), default=None)
+            if not best or SequenceMatcher(None, w, best).ratio() < 0.80:
+                continue
+            if expected_words and best not in expected_words:
+                continue
+            parts.append(f"'{w}' → '{best}'?")
+        return ("Check spelling: " + ", ".join(parts)) if parts else None
+    except Exception:
+        return None
+
+
+def _item_tag(wrong_count: int, hint_used: bool, auto_revealed: bool) -> str:
+    if auto_revealed or hint_used or wrong_count >= 2:
+        return "needs-practice"
+    if wrong_count == 1:
+        return "drill-reinforced"
+    return "drill-clean"
+
+
+def _drill_prompt(state: dict) -> str:
+    """Level 1 prompt: person fill-in."""
+    person = state["current"]
+    verb = state["verb"]
+    english = state["english"]
+    total = len(state["queue"])
+    return f"{verb} ({english}) — {state['pos']+1}/{total}\n\n{person} ___?"
+
+
+def _l2_prompt(state: dict) -> str:
+    """Level 2 prompt: translate this phrase."""
+    idx = state["queue"][state["pos"]]
+    phrase = state["phrases"][idx]
+    total = len(state["queue"])
+    return f"{state['pos']+1}/{total}\n\nHow do you say:\n\"{phrase['english']}\""
+
+
+def _start_drill_state(entry: dict) -> dict:
+    queue = random.sample(_DRILL_PERSONS, len(_DRILL_PERSONS))
+    return {
+        "verb":             entry["verb"],
+        "english":          entry.get("english", ""),
+        "conjugations":     entry.get("conjugations", {}),
+        "queue":            queue,
+        "pos":              0,
+        "current":          queue[0],
+        "score":            0,
+        "total":            0,
+        "retry":            False,
+        "items":            [],
+        "hint_used_current": False,
+        "l1_worst_tag":     "drill-clean",
+    }
+
+
+def _record_l2_item(state: dict, phrase: dict, wrong_count: int, auto_revealed: bool) -> None:
+    tag = _item_tag(wrong_count, state.get("hint_used_current", False), auto_revealed)
+    state["items"].append({
+        "front":  phrase["english"],
+        "back":   phrase["german"],
+        "result": tag,
+        "tags":   f"{tag} Vienna phrase {state['verb']}",
+    })
+    state["hint_used_current"] = False
+
+
+def _record_l1_person(state: dict, wrong_count: int, auto_revealed: bool) -> None:
+    tag = _item_tag(wrong_count, state.get("hint_used_current", False), auto_revealed)
+    priority = {"drill-clean": 0, "drill-reinforced": 1, "needs-practice": 2}
+    if priority.get(tag, 0) > priority.get(state.get("l1_worst_tag", "drill-clean"), 0):
+        state["l1_worst_tag"] = tag
+    state["hint_used_current"] = False
+
+
+def _finalize_l1_items(state: dict) -> None:
+    """Convert l1_worst_tag into one Anki item if any friction occurred."""
+    tag = state.get("l1_worst_tag", "drill-clean")
+    if tag == "drill-clean":
+        return
+    conj = state.get("conjugations", {})
+    table = " / ".join(
+        f"{dp} {conj.get(pp, '?')}"
+        for dp, pp in zip(_PERSONS_DISPLAY, _PERSONS_POOL)
+    )
+    state["items"].append({
+        "front":  f"{state['verb']} — {state.get('english', '')}",
+        "back":   table,
+        "result": tag,
+        "tags":   f"{tag} Vienna conjugation",
+    })

--- a/german_domain.py
+++ b/german_domain.py
@@ -271,3 +271,242 @@ def _finalize_l1_items(state: dict) -> None:
         "result": tag,
         "tags":   f"{tag} Vienna conjugation",
     })
+
+
+# ─── Domain I/O — file loaders and savers ────────────────────────────────────
+
+import json
+import subprocess
+
+_PHRASEBOOK_FILE       = GERMAN_DIR / "config" / "phrasebook.json"
+_DRILL_STATE_FILE      = _BASE_DIR / "_active_drill_state.json"
+_DRILL_LIST_STATE_FILE = _BASE_DIR / "_drill_list_state.json"
+
+
+def _load_keyword_map_bot() -> dict:
+    """Load keyword_map.json for bot routing — returns {} if missing."""
+    path = GERMAN_DIR / "config" / "keyword_map.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except Exception:
+        return {}
+
+
+def _last_session_persona() -> str | None:
+    """Return persona name from the most recent session JSON, or None."""
+    sessions_dir = GERMAN_DIR / "sessions"
+    if not sessions_dir.exists():
+        return None
+    sessions = sorted(sessions_dir.glob("*.json"))
+    if not sessions:
+        return None
+    try:
+        data = json.loads(sessions[-1].read_text(encoding="utf-8"))
+        return data.get("persona")
+    except Exception:
+        return None
+
+
+def _run(cmd, timeout=120, **kwargs):
+    """Run a subprocess, return (stdout, stderr, returncode)."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, **kwargs)
+        return result.stdout, result.stderr, result.returncode
+    except subprocess.TimeoutExpired:
+        return "", f"⏱ Timed out after {timeout}s", 1
+
+
+def _german_agent_mode() -> str:
+    cfg_path = GERMAN_DIR / "config" / "sync_config.json"
+    if cfg_path.exists():
+        try:
+            return json.loads(cfg_path.read_text()).get("agent_mode", "direct")
+        except Exception:
+            pass
+    return "direct"
+
+
+def _phrase_next_id(phrases: list, today: str) -> str:
+    """Global sequence — never resets per day, so short IDs (#001, #002...) stay unique."""
+    prefix = f"ph_{today.replace('-', '')}_"
+    all_ids = [p["id"] for p in phrases if isinstance(p, dict) and p.get("id")]
+    if not all_ids:
+        return f"{prefix}001"
+    maxn = max(int(pid.rsplit("_", 1)[-1]) for pid in all_ids)
+    return f"{prefix}{maxn + 1:03d}"
+
+
+def _load_drill_pool() -> dict:
+    pool_path = GERMAN_DIR / "config" / "drill_pool.json"
+    if pool_path.exists():
+        try:
+            return json.loads(pool_path.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def _save_drill_pool(pool: dict) -> None:
+    pool_path = GERMAN_DIR / "config" / "drill_pool.json"
+    pool_path.write_text(json.dumps(pool, indent=2, ensure_ascii=False))
+
+
+def _load_phrasebook() -> dict:
+    if _PHRASEBOOK_FILE.exists():
+        try:
+            return json.loads(_PHRASEBOOK_FILE.read_text())
+        except Exception:
+            pass
+    return {"phrases": []}
+
+
+def _save_phrasebook(data: dict) -> None:
+    _PHRASEBOOK_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def _write_drill_anki(state: dict) -> int:
+    """Append friction items from completed drill to vienna_deck.csv. Returns card count written."""
+    import csv as _csv
+    vienna_csv = GERMAN_DIR / "anki" / "vienna_deck.csv"
+    items = state.get("items", [])
+    friction = [it for it in items if it["result"] != "drill-clean"]
+    if not friction:
+        return 0
+
+    existing_fronts: set[str] = set()
+    if vienna_csv.exists():
+        try:
+            with open(vienna_csv, newline="", encoding="utf-8") as f:
+                for row in _csv.DictReader(f):
+                    existing_fronts.add(row.get("Front", "").strip())
+        except Exception:
+            pass
+
+    write_header = not vienna_csv.exists()
+    written = 0
+    try:
+        with open(vienna_csv, "a", newline="", encoding="utf-8") as f:
+            writer = _csv.writer(f, quoting=_csv.QUOTE_ALL)
+            if write_header:
+                writer.writerow(["Front", "Back", "Tags"])
+            for it in friction:
+                if it["front"].strip() in existing_fronts:
+                    continue
+                writer.writerow([it["front"], it["back"], it["tags"]])
+                existing_fronts.add(it["front"].strip())
+                written += 1
+    except Exception as e:
+        print(f"⚠️  Could not write drill Anki cards: {e}")
+    return written
+
+
+def _drill_completion_message(state: dict, reveal_line: str) -> str:
+    """Build completion message with Anki summary. Writes cards as side effect."""
+    score, total = state["score"], state["total"]
+    written = _write_drill_anki(state)
+    counts = {"drill-clean": 0, "drill-reinforced": 0, "needs-practice": 0}
+    for it in state.get("items", []):
+        counts[it["result"]] = counts.get(it["result"], 0) + 1
+    lines = [f"{reveal_line}\n\nDrill complete! {score}/{total} correct."]
+    if counts["drill-clean"] or counts["drill-reinforced"] or counts["needs-practice"]:
+        lines.append(
+            f"  ✅ Clean: {counts['drill-clean']}  "
+            f"📝 Reinforced: {counts['drill-reinforced']}  "
+            f"⚠️ Needs practice: {counts['needs-practice']}"
+        )
+    if written:
+        lines.append(f"  {written} card(s) added to vienna_deck.csv — reimport Anki to sync to phone.")
+    lines.append("(say 'again' to repeat)")
+    return "\n".join(lines)
+
+
+# ─── LLM calls ────────────────────────────────────────────────────────────────
+
+def _call_llm(prompt: str, max_tokens: int = 300) -> str | None:
+    """Call LLM providers in order, return text response or None if all fail."""
+    import keyring as _keyring
+    for provider in _LLM_PROVIDERS:
+        try:
+            if provider["type"] == "xai":
+                api_key = _keyring.get_password("xai", "api_key")
+                if not api_key:
+                    continue
+                from openai import OpenAI as _OpenAI
+                client = _OpenAI(api_key=api_key, base_url="https://api.x.ai/v1")
+                resp = client.chat.completions.create(
+                    model=provider["model"],
+                    max_tokens=max_tokens,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return resp.choices[0].message.content.strip()
+            elif provider["type"] == "anthropic":
+                api_key = _keyring.get_password("anthropic", "api_key")
+                if not api_key:
+                    continue
+                import anthropic as _anthropic
+                client = _anthropic.Anthropic(api_key=api_key)
+                msg = client.messages.create(
+                    model=provider["model"],
+                    max_tokens=max_tokens,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return msg.content[0].text.strip()
+            elif provider["type"] == "ollama":
+                from openai import OpenAI as _OpenAI
+                client = _OpenAI(api_key="ollama", base_url="http://localhost:11434/v1")
+                resp = client.chat.completions.create(
+                    model=provider["model"],
+                    max_tokens=max_tokens,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return resp.choices[0].message.content.strip()
+        except Exception as e:
+            print(f"⚠️  LLM provider '{provider['name']}' failed: {e}")
+            continue
+    return None
+
+
+def _fetch_conjugations(verb: str) -> dict | None:
+    """Fetch present-tense conjugations for any German verb via LLM, with fallback."""
+    prompt = (
+        f'Give me the present-tense conjugations of the German verb "{verb}" '
+        f'for these persons: ich, du, er, wir, ihr, sie. '
+        f'Also give a short English translation (infinitive). '
+        f'Reply ONLY with a JSON object in this exact format, no extra text:\n'
+        f'{{"verb":"{verb}","english":"...","conjugations":{{"ich":"...","du":"...","er":"...","wir":"...","ihr":"...","sie":"..."}}}}'
+    )
+    raw = _call_llm(prompt, max_tokens=200)
+    if not raw:
+        return None
+    try:
+        if raw.startswith("```"):
+            raw = raw.split("```")[1]
+            if raw.startswith("json"):
+                raw = raw[4:]
+        return json.loads(raw.strip())
+    except Exception as e:
+        print(f"⚠️  Failed to parse conjugation JSON for '{verb}': {e}\nRaw: {raw[:100]}")
+        return None
+
+
+def _fetch_phrases(verb: str, english: str) -> list:
+    """Generate translation phrases for a verb via LLM. Returns list of {english, german} dicts."""
+    prompt = (
+        f'Generate 6 natural German phrases using the verb "{verb}" ({english}). '
+        f'Mix informal (du/ich) and formal (Sie). Vienna-relevant contexts (café, hotel, transport, small talk). '
+        f'Reply ONLY with a JSON array, no extra text:\n'
+        f'[{{"english":"...","german":"..."}},{{"english":"...","german":"..."}}]'
+    )
+    raw = _call_llm(prompt, max_tokens=400)
+    if not raw:
+        return []
+    try:
+        if raw.startswith("```"):
+            raw = raw.split("```")[1]
+            if raw.startswith("json"):
+                raw = raw[4:]
+        result = json.loads(raw.strip())
+        return [p for p in result if isinstance(p, dict) and "english" in p and "german" in p]
+    except Exception as e:
+        print(f"⚠️  Failed to parse phrases JSON for '{verb}': {e}\nRaw: {raw[:100]}")
+        return []

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -27,6 +27,22 @@ from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler, MessageHandler, ContextTypes
 from telegram.ext import filters
 from telegram.error import NetworkError, TimedOut
+from german_domain import (
+    ROBERT_CHAT_ID, GERMAN_BASE, GERMAN_DIR, VENV_PYTHON,
+    _WRITING_RE, _SESSION_RE, _CONJUGATE_RE,
+    _DRILL_RE, _DRILL_L2_RE, _DRILL_CTL_RE, _DRILL_AGAIN_RE,
+    _DRILL_LIST_RE, _DRILL_MORE_RE, _SKIP_LESSON_RE, _AGAIN_RE,
+    _PHRASE_CAPTURE_RE, _PHRASE_PRACTICE_VOICE_RE,
+    _PHRASE_LIST_VOICE_RE, _PHRASE_LIST_MORE_VOICE_RE,
+    _SPOKEN_NUMBERS, _LLM_PROVIDERS,
+    _DE_CONTRACTIONS, _DE_CONTRACTION_RE,
+    _DRILL_PERSONS, _PERSONS_DISPLAY, _PERSONS_POOL,
+    _resolve_keyword_intent, _parse_spoken_id,
+    _all_verb_entries, _lookup_verb,
+    _expand_contractions, _normalize_answer, _spell_feedback,
+    _item_tag, _drill_prompt, _l2_prompt,
+    _start_drill_state, _record_l2_item, _record_l1_person, _finalize_l1_items,
+)
 
 BASE_DIR = Path(__file__).parent
 processed_callbacks = set()
@@ -564,46 +580,9 @@ def run_send_mode():
 
 # ─── German domain text handlers ─────────────────────────────────────────────
 
-ROBERT_CHAT_ID = 8379221702
-GERMAN_BASE = BASE_DIR / "_NewDomains" / "language-german"
-GERMAN_DIR  = GERMAN_BASE / "language" / "german"
-VENV_PYTHON = BASE_DIR / "venv" / "bin" / "python3"
-
-_WRITING_RE = re.compile(
-    r"(writing session|written session|"
-    r"session.{0,20}writing|writing.{0,20}session|"
-    r"next.{0,20}german.{0,20}writing|german.{0,20}writing)",
-    re.I,
-)
-_SESSION_RE = re.compile(
-    r"(pull today.?s german session|what.?s my german session|"
-    r"give me today.?s german prompt|german session please|"
-    r"german session today|today.?s german session|"
-    r"german session|session german|next session|next lesson|"
-    r"start.{0,30}german|start.{0,30}session.{0,30}german|"
-    r"let.{0,10}s.{0,10}german)",
-    re.I,
-)
-_CONJUGATE_RE = re.compile(r'\bconjugate\s+(\w+)\b', re.I)
-_DRILL_RE = re.compile(
-    r'(german\s+drill|drill\s+german|drill\s+mode|start\s+drill|drill\s+(?:level\s*2|l2|translate|verb|noun|word|vocab|my\s+mistakes|errors?|\d+\s+[a-zäöüß]{3,}|[a-zäöüß]{3,}))',
-    re.I,
-)
-_DRILL_L2_RE = re.compile(r'\b(?:level\s*2|l2|translate|phrases?|2)\b', re.I)
-_DRILL_CTL_RE = re.compile(r'\b(?:end(?:\s+drill)?|done|stop|quit|enough)\b', re.I)
-_DRILL_AGAIN_RE = re.compile(r'\b(?:again|repeat|once more|one more)\b', re.I)
-_DRILL_LIST_RE = re.compile(r'\b(?:drill\s+(?:\w+\s+)?list|list\s+(?:drills?|verbs?)|verbs?\s+list|show\s+verbs?|what\s+verbs?)\b', re.I)
-_DRILL_MORE_RE = re.compile(r'\b(?:more|next)\b', re.I)
-_SKIP_LESSON_RE = re.compile(
-    r'\b(?:skip\s+(?:lesson|session|this\s+one)|next\s+one|different\s+scene)\b',
-    re.I,
-)
-
-
-_AGAIN_RE = re.compile(
-    r"\b(again|one more|repeat|same (session|persona|scenario)|do it again)\b",
-    re.I,
-)
+# ROBERT_CHAT_ID, GERMAN_BASE, GERMAN_DIR, VENV_PYTHON,
+# regex patterns (_SESSION_RE, _DRILL_RE, etc.), and _AGAIN_RE
+# are imported from german_domain
 
 
 def _load_keyword_map_bot() -> dict:
@@ -615,28 +594,7 @@ def _load_keyword_map_bot() -> dict:
         return {}
 
 
-def _resolve_keyword_intent(text: str, keyword_map: dict) -> tuple[str, str] | None:
-    """
-    Match trigger words from keyword_map against text.
-    Returns (persona_name, scenario) or None.
-
-    Safety rule: a lone trigger word with no surrounding context does not fire.
-    The message must have >=2 words OR contain 'german'/'session' alongside the keyword.
-    """
-    if not keyword_map:
-        return None
-
-    words = text.lower().split()
-    if len(words) < 2:
-        return None
-
-    for persona_name, data in keyword_map.items():
-        for trigger in data.get("trigger_words", []):
-            trigger_lower = trigger.lower()
-            if trigger_lower in text.lower():
-                return (persona_name, data.get("default_scenario", ""))
-
-    return None
+# _resolve_keyword_intent imported from german_domain
 
 
 def _last_session_persona() -> str | None:
@@ -995,35 +953,9 @@ _phrase_save_pending: dict = {}  # chat_id → {"german": str, "english": str}; 
 _phrase_capture_mode: dict = {}  # chat_id → {"retries": int}; waiting for second voice note with the phrase
                                  # in-memory only — gap between trigger and phrase note is seconds; restart cost is re-triggering
 
-_PHRASE_CAPTURE_RE = re.compile(
-    r'\b(?:save\s+(?:a\s+)?phrase|capture\s+(?:this|a\s+phrase|phrase)|'
-    r'add?\s+(?:a\s+)?phrase|phrase\s+(?:add|capture|merken|speichern)|'
-    r'new\s+phrase|start\s+phrase\s+capture|neue\s+phrase|das\s+merken)\b',
-    re.I
-)
-_PHRASE_PRACTICE_VOICE_RE = re.compile(
-    r'\b(?:phra?se\s+practice|practice\s+(?:a\s+)?phra?se|phrase\s+üben)\b', re.I
-)
-_SPOKEN_NUMBERS = {
-    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
-    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10,
-}
-
-def _parse_spoken_id(text: str) -> str:
-    """Convert spoken phrase id to zero-padded string: 'one' → '001', '3' → '003'."""
-    import re as _re
-    t = _re.sub(r'^number\s+', '', text.strip().strip(".,!? "), flags=_re.I).strip()
-    m = _re.search(r'\d+', t)
-    if m:
-        return f"{int(m.group()):03d}"
-    word = t.lower().strip(".,")
-    return f"{_SPOKEN_NUMBERS[word]:03d}" if word in _SPOKEN_NUMBERS else t
-_PHRASE_LIST_VOICE_RE = re.compile(
-    r'\b(?:phrase\s+list|list\s+(?:my\s+)?phrases?|show\s+(?:my\s+)?phrases?|my\s+phrases?)\b', re.I
-)
-_PHRASE_LIST_MORE_VOICE_RE = re.compile(
-    r'\b(?:phrase\s+more|more\s+phrases?|next\s+phrases?)\b', re.I
-)
+# _PHRASE_CAPTURE_RE, _PHRASE_PRACTICE_VOICE_RE, _SPOKEN_NUMBERS,
+# _parse_spoken_id, _PHRASE_LIST_VOICE_RE, _PHRASE_LIST_MORE_VOICE_RE
+# are imported from german_domain
 
 _phrase_list_offset: dict = {}  # chat_id → int; tracks pagination offset for !phrase list more
 
@@ -1051,24 +983,7 @@ def _phrase_next_id(phrases: list, today: str) -> str:
     return f"{prefix}{maxn + 1:03d}"
 
 
-def _all_verb_entries(pool: dict) -> list:
-    """Return all verb entries from core + on_demand, core takes precedence."""
-    core = [v for v in pool.get("core", {}).get("verbs", []) if isinstance(v, dict) and "verb" in v]
-    on_demand = [v for v in pool.get("on_demand", {}).get("verbs", []) if isinstance(v, dict) and "verb" in v]
-    core_names = {v["verb"].lower() for v in core}
-    return core + [v for v in on_demand if v["verb"].lower() not in core_names]
-
-
-def _lookup_verb(pool: dict, verb_lower: str) -> dict | None:
-    return next((v for v in _all_verb_entries(pool) if v["verb"].lower() == verb_lower), None)
-
-
-# LLM providers tried in order — reorder to change preference, no key changes needed
-_LLM_PROVIDERS = [
-    {"name": "grok-mini",     "type": "xai",       "model": "grok-3-mini"},
-    {"name": "claude-haiku",  "type": "anthropic",  "model": "claude-haiku-4-5-20251001"},
-    {"name": "ollama-gemma",  "type": "ollama",     "model": "gemma3:1b"},
-]
+# _all_verb_entries, _lookup_verb, _LLM_PROVIDERS imported from german_domain
 
 
 def _call_llm(prompt: str, max_tokens: int = 300) -> str | None:
@@ -1199,60 +1114,8 @@ async def _resolve_phrases(update, entry: dict) -> list:
     return phrases
 
 
-_DE_CONTRACTIONS = {
-    "beim": "bei dem",
-    "im": "in dem",
-    "am": "an dem",
-    "vom": "von dem",
-    "zum": "zu dem",
-    "zur": "zu der",
-    "ans": "an das",
-    "ins": "in das",
-    "aufs": "auf das",
-    "ums": "um das",
-}
-_DE_CONTRACTION_RE = re.compile(
-    r'\b(' + '|'.join(re.escape(k) for k in _DE_CONTRACTIONS) + r')\b', re.IGNORECASE
-)
-
-def _expand_contractions(text: str) -> str:
-    """Expand German preposition+article contractions to canonical long form."""
-    return _DE_CONTRACTION_RE.sub(lambda m: _DE_CONTRACTIONS[m.group(0).lower()], text)
-
-def _normalize_answer(text: str) -> str:
-    """Lowercase, strip punctuation, expand contractions, collapse whitespace."""
-    text = text.lower().strip()
-    text = re.sub(r'[^\w\s]', ' ', text)
-    text = _expand_contractions(text)
-    return " ".join(text.split())
-
-
-def _spell_feedback(normalized_answer: str, expected: str = "") -> str | None:
-    """Return feedback for misspelled German words. Input must already be normalized (no punctuation, lowercase).
-    If expected is given, only suggest corrections that appear in the expected answer."""
-    try:
-        from spellchecker import SpellChecker
-        from difflib import SequenceMatcher
-        checker = SpellChecker(language="de")
-        expected_words = set(expected.split()) if expected else set()
-        words = [w for w in normalized_answer.split() if len(w) >= 3]
-        unknown = checker.unknown(words)
-        if not unknown:
-            return None
-        parts = []
-        for w in unknown:
-            candidates = checker.candidates(w) or set()
-            # Only suggest a correction if it's actually close (avoids 'danube' → 'laube')
-            best = max(candidates, key=lambda c: SequenceMatcher(None, w, c).ratio(), default=None)
-            if not best or SequenceMatcher(None, w, best).ratio() < 0.80:
-                continue
-            # If expected is known, skip suggestions that don't appear in the expected answer
-            if expected_words and best not in expected_words:
-                continue
-            parts.append(f"'{w}' → '{best}'?")
-        return ("Check spelling: " + ", ".join(parts)) if parts else None
-    except Exception:
-        return None
+# _DE_CONTRACTIONS, _DE_CONTRACTION_RE, _expand_contractions,
+# _normalize_answer, _spell_feedback imported from german_domain
 
 
 async def _handle_conjugate(update, verb: str) -> None:
@@ -1325,18 +1188,7 @@ def _load_drill_state() -> None:
     except Exception as e:
         print(f"⚠️  Could not restore drill state: {e}")
 
-_DRILL_PERSONS = ["ich", "du", "er", "wir", "ihr", "sie"]
-
-_PERSONS_DISPLAY = ["ich", "du", "er/sie/es", "wir", "ihr", "sie/Sie"]
-_PERSONS_POOL    = ["ich", "du", "er",         "wir", "ihr", "sie"]
-
-
-def _item_tag(wrong_count: int, hint_used: bool, auto_revealed: bool) -> str:
-    if auto_revealed or hint_used or wrong_count >= 2:
-        return "needs-practice"
-    if wrong_count == 1:
-        return "drill-reinforced"
-    return "drill-clean"
+# _DRILL_PERSONS, _PERSONS_DISPLAY, _PERSONS_POOL, _item_tag imported from german_domain
 
 
 def _write_drill_anki(state: dict) -> int:
@@ -1395,77 +1247,8 @@ def _drill_completion_message(state: dict, reveal_line: str) -> str:
     return "\n".join(lines)
 
 
-def _drill_prompt(state: dict) -> str:
-    """Level 1 prompt: person fill-in."""
-    person = state["current"]
-    verb = state["verb"]
-    english = state["english"]
-    total = len(state["queue"])
-    return f"{verb} ({english}) — {state['pos']+1}/{total}\n\n{person} ___?"
-
-
-def _l2_prompt(state: dict) -> str:
-    """Level 2 prompt: translate this phrase."""
-    idx = state["queue"][state["pos"]]
-    phrase = state["phrases"][idx]
-    total = len(state["queue"])
-    return f"{state['pos']+1}/{total}\n\nHow do you say:\n\"{phrase['english']}\""
-
-
-def _start_drill_state(entry: dict) -> dict:
-    import random
-    queue = random.sample(_DRILL_PERSONS, len(_DRILL_PERSONS))
-    return {
-        "verb": entry["verb"],
-        "english": entry.get("english", ""),
-        "conjugations": entry.get("conjugations", {}),
-        "queue": queue,
-        "pos": 0,
-        "current": queue[0],
-        "score": 0,
-        "total": 0,
-        "retry": False,
-        "items": [],
-        "hint_used_current": False,
-        "l1_worst_tag": "drill-clean",
-    }
-
-
-def _record_l2_item(state: dict, phrase: dict, wrong_count: int, auto_revealed: bool) -> None:
-    tag = _item_tag(wrong_count, state.get("hint_used_current", False), auto_revealed)
-    state["items"].append({
-        "front": phrase["english"],
-        "back": phrase["german"],
-        "result": tag,
-        "tags": f"{tag} Vienna phrase {state['verb']}",
-    })
-    state["hint_used_current"] = False
-
-
-def _record_l1_person(state: dict, wrong_count: int, auto_revealed: bool) -> None:
-    tag = _item_tag(wrong_count, state.get("hint_used_current", False), auto_revealed)
-    priority = {"drill-clean": 0, "drill-reinforced": 1, "needs-practice": 2}
-    if priority.get(tag, 0) > priority.get(state.get("l1_worst_tag", "drill-clean"), 0):
-        state["l1_worst_tag"] = tag
-    state["hint_used_current"] = False
-
-
-def _finalize_l1_items(state: dict) -> None:
-    """Convert l1_worst_tag into one Anki item if any friction occurred."""
-    tag = state.get("l1_worst_tag", "drill-clean")
-    if tag == "drill-clean":
-        return
-    conj = state.get("conjugations", {})
-    table = " / ".join(
-        f"{dp} {conj.get(pp, '?')}"
-        for dp, pp in zip(_PERSONS_DISPLAY, _PERSONS_POOL)
-    )
-    state["items"].append({
-        "front": f"{state['verb']} — {state.get('english', '')}",
-        "back": table,
-        "result": tag,
-        "tags": f"{tag} Vienna conjugation",
-    })
+# _drill_prompt, _l2_prompt, _start_drill_state, _record_l2_item,
+# _record_l1_person, _finalize_l1_items imported from german_domain
 
 
 async def _resolve_drill_verb(update, target_lower: str) -> dict | None:

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -50,6 +50,8 @@ from german_domain import (
     _load_phrasebook, _save_phrasebook,
     _call_llm, _fetch_conjugations, _fetch_phrases,
     _write_drill_anki, _drill_completion_message,
+    # Group C — async-free resolvers with callback pattern
+    _resolve_verb, _resolve_phrases, _resolve_drill_verb,
 )
 
 BASE_DIR = Path(__file__).parent
@@ -908,46 +910,7 @@ _phrase_capture_mode: dict = {}  # chat_id → {"retries": int}; waiting for sec
 _phrase_list_offset: dict = {}   # chat_id → int; pagination offset for phrase list
 
 
-async def _resolve_verb(update, verb_lower: str) -> dict | None:
-    """Find verb in pool or fetch via Claude and cache it. Returns entry or None."""
-    pool = _load_drill_pool()
-    entry = _lookup_verb(pool, verb_lower)
-    if entry:
-        return entry
-    await update.message.reply_text(f"Looking up '{verb_lower}'…")
-    entry = _fetch_conjugations(verb_lower)
-    if not entry:
-        await update.message.reply_text(f"Couldn't look up '{verb_lower}' — check spelling.")
-        return None
-    # Cache in on_demand
-    on_demand_verbs = pool.setdefault("on_demand", {}).setdefault("verbs", [])
-    on_demand_verbs.append(entry)
-    _save_drill_pool(pool)
-    return entry
-
-
-# _fetch_phrases imported from german_domain
-
-
-async def _resolve_phrases(update, entry: dict) -> list:
-    """Return cached phrases for a verb entry, or fetch+cache via LLM."""
-    if entry.get("phrases"):
-        return entry["phrases"]
-    await update.message.reply_text(f"Generating phrases for {entry['verb']}…")
-    phrases = _fetch_phrases(entry["verb"], entry.get("english", ""))
-    if not phrases:
-        await update.message.reply_text(f"Couldn't generate phrases for '{entry['verb']}'.")
-        return []
-    # Cache phrases back into the entry in drill_pool.json
-    pool = _load_drill_pool()
-    for section in (pool.get("core", {}).get("verbs", []), pool.get("on_demand", {}).get("verbs", [])):
-        for v in section:
-            if isinstance(v, dict) and v.get("verb", "").lower() == entry["verb"].lower():
-                v["phrases"] = phrases
-                break
-    _save_drill_pool(pool)
-    entry["phrases"] = phrases
-    return phrases
+# _resolve_verb, _resolve_phrases imported from german_domain (Group C)
 
 
 # _DE_CONTRACTIONS, _DE_CONTRACTION_RE, _expand_contractions,
@@ -956,7 +919,8 @@ async def _resolve_phrases(update, entry: dict) -> list:
 
 async def _handle_conjugate(update, verb: str) -> None:
     """Level 0 conjugate flashcard — any verb, looks up via Claude if needed."""
-    entry = await _resolve_verb(update, verb.lower())
+    async def _cb(msg): await update.message.reply_text(msg)
+    entry = _resolve_verb(verb.lower(), progress_cb=_cb)
     if not entry:
         return
     c = entry.get("conjugations", {})
@@ -975,8 +939,7 @@ _active_drills: dict = {}  # chat_id → drill state; persisted to disk across r
 _last_drills: dict = {}   # chat_id → {verb, level, english} snapshot after completion
 _drill_list_state: dict = {}  # chat_id → {verbs: list, offset: int} for paginated listing
 
-_DRILL_STATE_FILE = BASE_DIR / "_active_drill_state.json"
-_DRILL_LIST_STATE_FILE = BASE_DIR / "_drill_list_state.json"
+# _DRILL_STATE_FILE, _DRILL_LIST_STATE_FILE imported from german_domain
 
 
 def _save_drill_list_state() -> None:
@@ -1030,32 +993,7 @@ def _load_drill_state() -> None:
 # _record_l1_person, _finalize_l1_items imported from german_domain
 
 
-async def _resolve_drill_verb(update, target_lower: str) -> dict | None:
-    """Extract verb from trigger text, look up or fetch. Returns entry or None."""
-    pool = _load_drill_pool()
-    all_verbs = _all_verb_entries(pool)
-    entry = next((v for v in all_verbs if v["verb"].lower() in target_lower), None)
-    if entry:
-        return entry
-    stop_words = {"drill", "german", "mode", "start", "verb", "my", "errors", "mistakes", "level", "translate", "l2", "phrase", "phrases"}
-    words = [w for w in target_lower.split() if w not in stop_words and len(w) > 3 and not w.isdigit()]
-    if words:
-        word = words[0]
-        # Check if word matches a scene tag — don't send nouns/scenes to LLM for conjugation.
-        # Pick a random verb from that scene instead.
-        all_scenes = {s for v in all_verbs for s in v.get("scenes", [])}
-        if word in all_scenes:
-            import random
-            scene_verbs = [v for v in all_verbs if word in v.get("scenes", [])]
-            if scene_verbs:
-                chosen = random.choice(scene_verbs)
-                await update.message.reply_text(
-                    f"'{word}' is a scene, not a verb — picking {chosen['verb']} ({chosen.get('english','')}) from that scene."
-                )
-                return chosen
-        return await _resolve_verb(update, word)
-    import random
-    return random.choice(all_verbs) if all_verbs else None
+# _resolve_drill_verb imported from german_domain (Group C)
 
 
 async def _handle_drill(update, target: str) -> None:
@@ -1069,7 +1007,8 @@ async def _handle_drill(update, target: str) -> None:
 
 async def _handle_drill_l1_start(update, target_lower: str) -> None:
     """Start a Level 1 conjugation drill — any verb, random if none specified."""
-    entry = await _resolve_drill_verb(update, target_lower)
+    async def _cb(msg): await update.message.reply_text(msg)
+    entry = _resolve_drill_verb(target_lower, progress_cb=_cb)
     if not entry:
         await update.message.reply_text("No verbs in drill pool yet.")
         return
@@ -1086,13 +1025,14 @@ async def _handle_drill_l1_start(update, target_lower: str) -> None:
 
 async def _handle_drill_l2_start(update, target_lower: str) -> None:
     """Start a Level 2 translation drill — any verb, random if none specified."""
-    entry = await _resolve_drill_verb(update, target_lower)
+    async def _cb(msg): await update.message.reply_text(msg)
+    entry = _resolve_drill_verb(target_lower, progress_cb=_cb)
     if not entry:
         await update.message.reply_text("No verbs in drill pool yet.")
         return
     _drill_list_state.pop(update.message.chat_id, None)
     _save_drill_list_state()
-    phrases = await _resolve_phrases(update, entry)
+    phrases = _resolve_phrases(entry, progress_cb=_cb)
     if not phrases:
         return
     import random

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -28,6 +28,7 @@ from telegram.ext import Application, CallbackQueryHandler, CommandHandler, Mess
 from telegram.ext import filters
 from telegram.error import NetworkError, TimedOut
 from german_domain import (
+    # Group A — constants and pure functions
     ROBERT_CHAT_ID, GERMAN_BASE, GERMAN_DIR, VENV_PYTHON,
     _WRITING_RE, _SESSION_RE, _CONJUGATE_RE,
     _DRILL_RE, _DRILL_L2_RE, _DRILL_CTL_RE, _DRILL_AGAIN_RE,
@@ -42,6 +43,13 @@ from german_domain import (
     _expand_contractions, _normalize_answer, _spell_feedback,
     _item_tag, _drill_prompt, _l2_prompt,
     _start_drill_state, _record_l2_item, _record_l1_person, _finalize_l1_items,
+    # Group B — I/O and LLM functions
+    _PHRASEBOOK_FILE, _DRILL_STATE_FILE, _DRILL_LIST_STATE_FILE,
+    _load_keyword_map_bot, _last_session_persona, _run, _german_agent_mode,
+    _phrase_next_id, _load_drill_pool, _save_drill_pool,
+    _load_phrasebook, _save_phrasebook,
+    _call_llm, _fetch_conjugations, _fetch_phrases,
+    _write_drill_anki, _drill_completion_message,
 )
 
 BASE_DIR = Path(__file__).parent
@@ -585,43 +593,9 @@ def run_send_mode():
 # are imported from german_domain
 
 
-def _load_keyword_map_bot() -> dict:
-    """Load keyword_map.json for bot routing — returns {} if missing."""
-    path = GERMAN_DIR / "config" / "keyword_map.json"
-    try:
-        return json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-    except Exception:
-        return {}
-
-
-# _resolve_keyword_intent imported from german_domain
-
-
-def _last_session_persona() -> str | None:
-    """Return persona name from the most recent session JSON, or None."""
-    sessions_dir = GERMAN_DIR / "sessions"
-    if not sessions_dir.exists():
-        return None
-    sessions = sorted(sessions_dir.glob("*.json"))
-    if not sessions:
-        return None
-    try:
-        data = json.loads(sessions[-1].read_text(encoding="utf-8"))
-        return data.get("persona")
-    except Exception:
-        return None
-
+# _load_keyword_map_bot, _last_session_persona, _run imported from german_domain
 
 KEYWORD_MAP = _load_keyword_map_bot()
-
-
-def _run(cmd, timeout=120, **kwargs):
-    """Run a subprocess, return (stdout, stderr, returncode)."""
-    try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, **kwargs)
-        return result.stdout, result.stderr, result.returncode
-    except subprocess.TimeoutExpired:
-        return "", f"⏱ Timed out after {timeout}s", 1
 
 
 async def _arun(cmd, timeout=120, **kwargs):
@@ -674,14 +648,7 @@ async def _handle_german_transcript(update: Update, text: str):
     await update.message.reply_text(f"<pre>{escape(out)}</pre>", parse_mode="HTML")
 
 
-def _german_agent_mode() -> str:
-    cfg_path = GERMAN_DIR / "config" / "sync_config.json"
-    if cfg_path.exists():
-        try:
-            return json.loads(cfg_path.read_text()).get("agent_mode", "direct")
-        except Exception:
-            pass
-    return "direct"
+# _german_agent_mode imported from german_domain
 
 
 async def _handle_german_command(update: Update, text: str):
@@ -931,125 +898,14 @@ async def _handle_skip_lesson(update) -> None:
         await update.message.reply_text(confirmation)
 
 
-def _load_drill_pool() -> dict:
-    pool_path = GERMAN_DIR / "config" / "drill_pool.json"
-    if pool_path.exists():
-        try:
-            return json.loads(pool_path.read_text())
-        except Exception:
-            pass
-    return {}
+# _load_drill_pool, _save_drill_pool, _PHRASEBOOK_FILE,
+# _load_phrasebook, _save_phrasebook, _phrase_next_id,
+# _call_llm, _fetch_conjugations imported from german_domain
 
-
-def _save_drill_pool(pool: dict) -> None:
-    pool_path = GERMAN_DIR / "config" / "drill_pool.json"
-    pool_path.write_text(json.dumps(pool, indent=2, ensure_ascii=False))
-
-
-_PHRASEBOOK_FILE = GERMAN_DIR / "config" / "phrasebook.json"
 _phrase_practice: dict = {}     # chat_id → {"phrase_id": str}; in-memory, survives restarts fine
 _phrase_save_pending: dict = {}  # chat_id → {"german": str, "english": str}; awaiting yes/no confirm
-                                 # in-memory only — lost on bot restart; user resubmits with !phrase if this happens
-_phrase_capture_mode: dict = {}  # chat_id → {"retries": int}; waiting for second voice note with the phrase
-                                 # in-memory only — gap between trigger and phrase note is seconds; restart cost is re-triggering
-
-# _PHRASE_CAPTURE_RE, _PHRASE_PRACTICE_VOICE_RE, _SPOKEN_NUMBERS,
-# _parse_spoken_id, _PHRASE_LIST_VOICE_RE, _PHRASE_LIST_MORE_VOICE_RE
-# are imported from german_domain
-
-_phrase_list_offset: dict = {}  # chat_id → int; tracks pagination offset for !phrase list more
-
-
-def _load_phrasebook() -> dict:
-    if _PHRASEBOOK_FILE.exists():
-        try:
-            return json.loads(_PHRASEBOOK_FILE.read_text())
-        except Exception:
-            pass
-    return {"phrases": []}
-
-
-def _save_phrasebook(data: dict) -> None:
-    _PHRASEBOOK_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False))
-
-
-def _phrase_next_id(phrases: list, today: str) -> str:
-    """Global sequence — never resets per day, so short IDs (#001, #002...) stay unique."""
-    prefix = f"ph_{today.replace('-', '')}_"
-    all_ids = [p["id"] for p in phrases if isinstance(p, dict) and p.get("id")]
-    if not all_ids:
-        return f"{prefix}001"
-    maxn = max(int(pid.rsplit("_", 1)[-1]) for pid in all_ids)
-    return f"{prefix}{maxn + 1:03d}"
-
-
-# _all_verb_entries, _lookup_verb, _LLM_PROVIDERS imported from german_domain
-
-
-def _call_llm(prompt: str, max_tokens: int = 300) -> str | None:
-    """Call LLM providers in order, return text response or None if all fail."""
-    for provider in _LLM_PROVIDERS:
-        try:
-            if provider["type"] == "xai":
-                api_key = keyring.get_password("xai", "api_key")
-                if not api_key:
-                    continue
-                from openai import OpenAI as _OpenAI
-                client = _OpenAI(api_key=api_key, base_url="https://api.x.ai/v1")
-                resp = client.chat.completions.create(
-                    model=provider["model"],
-                    max_tokens=max_tokens,
-                    messages=[{"role": "user", "content": prompt}],
-                )
-                return resp.choices[0].message.content.strip()
-            elif provider["type"] == "anthropic":
-                api_key = keyring.get_password("anthropic", "api_key")
-                if not api_key:
-                    continue
-                import anthropic as _anthropic
-                client = _anthropic.Anthropic(api_key=api_key)
-                msg = client.messages.create(
-                    model=provider["model"],
-                    max_tokens=max_tokens,
-                    messages=[{"role": "user", "content": prompt}],
-                )
-                return msg.content[0].text.strip()
-            elif provider["type"] == "ollama":
-                from openai import OpenAI as _OpenAI
-                client = _OpenAI(api_key="ollama", base_url="http://localhost:11434/v1")
-                resp = client.chat.completions.create(
-                    model=provider["model"],
-                    max_tokens=max_tokens,
-                    messages=[{"role": "user", "content": prompt}],
-                )
-                return resp.choices[0].message.content.strip()
-        except Exception as e:
-            print(f"⚠️  LLM provider '{provider['name']}' failed: {e}")
-            continue
-    return None
-
-
-def _fetch_conjugations(verb: str) -> dict | None:
-    """Fetch present-tense conjugations for any German verb via LLM, with fallback."""
-    prompt = (
-        f'Give me the present-tense conjugations of the German verb "{verb}" '
-        f'for these persons: ich, du, er, wir, ihr, sie. '
-        f'Also give a short English translation (infinitive). '
-        f'Reply ONLY with a JSON object in this exact format, no extra text:\n'
-        f'{{"verb":"{verb}","english":"...","conjugations":{{"ich":"...","du":"...","er":"...","wir":"...","ihr":"...","sie":"..."}}}}'
-    )
-    raw = _call_llm(prompt, max_tokens=200)
-    if not raw:
-        return None
-    try:
-        if raw.startswith("```"):
-            raw = raw.split("```")[1]
-            if raw.startswith("json"):
-                raw = raw[4:]
-        return json.loads(raw.strip())
-    except Exception as e:
-        print(f"⚠️  Failed to parse conjugation JSON for '{verb}': {e}\nRaw: {raw[:100]}")
-        return None
+_phrase_capture_mode: dict = {}  # chat_id → {"retries": int}; waiting for second voice note
+_phrase_list_offset: dict = {}   # chat_id → int; pagination offset for phrase list
 
 
 async def _resolve_verb(update, verb_lower: str) -> dict | None:
@@ -1070,27 +926,7 @@ async def _resolve_verb(update, verb_lower: str) -> dict | None:
     return entry
 
 
-def _fetch_phrases(verb: str, english: str) -> list:
-    """Generate translation phrases for a verb via LLM. Returns list of {english, german} dicts."""
-    prompt = (
-        f'Generate 6 natural German phrases using the verb "{verb}" ({english}). '
-        f'Mix informal (du/ich) and formal (Sie). Vienna-relevant contexts (café, hotel, transport, small talk). '
-        f'Reply ONLY with a JSON array, no extra text:\n'
-        f'[{{"english":"...","german":"..."}},{{"english":"...","german":"..."}}]'
-    )
-    raw = _call_llm(prompt, max_tokens=400)
-    if not raw:
-        return []
-    try:
-        if raw.startswith("```"):
-            raw = raw.split("```")[1]
-            if raw.startswith("json"):
-                raw = raw[4:]
-        result = json.loads(raw.strip())
-        return [p for p in result if isinstance(p, dict) and "english" in p and "german" in p]
-    except Exception as e:
-        print(f"⚠️  Failed to parse phrases JSON for '{verb}': {e}\nRaw: {raw[:100]}")
-        return []
+# _fetch_phrases imported from german_domain
 
 
 async def _resolve_phrases(update, entry: dict) -> list:
@@ -1188,65 +1024,8 @@ def _load_drill_state() -> None:
     except Exception as e:
         print(f"⚠️  Could not restore drill state: {e}")
 
-# _DRILL_PERSONS, _PERSONS_DISPLAY, _PERSONS_POOL, _item_tag imported from german_domain
-
-
-def _write_drill_anki(state: dict) -> int:
-    """Append friction items from completed drill to vienna_deck.csv. Returns card count written."""
-    import csv as _csv
-    vienna_csv = GERMAN_DIR / "anki" / "vienna_deck.csv"
-    items = state.get("items", [])
-    friction = [it for it in items if it["result"] != "drill-clean"]
-    if not friction:
-        return 0
-
-    existing_fronts: set[str] = set()
-    if vienna_csv.exists():
-        try:
-            with open(vienna_csv, newline="", encoding="utf-8") as f:
-                for row in _csv.DictReader(f):
-                    existing_fronts.add(row.get("Front", "").strip())
-        except Exception:
-            pass
-
-    write_header = not vienna_csv.exists()
-    written = 0
-    try:
-        with open(vienna_csv, "a", newline="", encoding="utf-8") as f:
-            writer = _csv.writer(f, quoting=_csv.QUOTE_ALL)
-            if write_header:
-                writer.writerow(["Front", "Back", "Tags"])
-            for it in friction:
-                if it["front"].strip() in existing_fronts:
-                    continue
-                writer.writerow([it["front"], it["back"], it["tags"]])
-                existing_fronts.add(it["front"].strip())
-                written += 1
-    except Exception as e:
-        print(f"⚠️  Could not write drill Anki cards: {e}")
-    return written
-
-
-def _drill_completion_message(state: dict, reveal_line: str) -> str:
-    """Build completion message with Anki summary. Writes cards as side effect."""
-    score, total = state["score"], state["total"]
-    written = _write_drill_anki(state)
-    counts = {"drill-clean": 0, "drill-reinforced": 0, "needs-practice": 0}
-    for it in state.get("items", []):
-        counts[it["result"]] = counts.get(it["result"], 0) + 1
-    lines = [f"{reveal_line}\n\nDrill complete! {score}/{total} correct."]
-    if counts["drill-clean"] or counts["drill-reinforced"] or counts["needs-practice"]:
-        lines.append(
-            f"  ✅ Clean: {counts['drill-clean']}  "
-            f"📝 Reinforced: {counts['drill-reinforced']}  "
-            f"⚠️ Needs practice: {counts['needs-practice']}"
-        )
-    if written:
-        lines.append(f"  {written} card(s) added to vienna_deck.csv — reimport Anki to sync to phone.")
-    lines.append("(say 'again' to repeat)")
-    return "\n".join(lines)
-
-
+# _DRILL_PERSONS, _PERSONS_DISPLAY, _PERSONS_POOL, _item_tag,
+# _write_drill_anki, _drill_completion_message,
 # _drill_prompt, _l2_prompt, _start_drill_state, _record_l2_item,
 # _record_l1_person, _finalize_l1_items imported from german_domain
 

--- a/test_reporter.py
+++ b/test_reporter.py
@@ -1,0 +1,182 @@
+"""
+test_reporter.py — Shared build-phase test reporter.
+
+Used by all domain test suites. Provides consistent failure visibility,
+dated report files, and cross-suite build stats.
+
+Usage in a test file:
+    from test_reporter import TestReporter
+    runner = TestReporter(suite="german_domain", group="Group A")
+    runner.report("D01", "normalize: strips punctuation", passed,
+                  expected="ich bin", got=result)
+    runner.finish()   # prints summary, writes report, sys.exit(0|1)
+
+Stats across all suites:
+    python3 test_reporter.py --stats [--suite german_domain]
+
+Ways of working:
+    - Every build phase that touches a domain module ships with a test file
+      that uses this reporter.
+    - Reports are written to _working/test_<suite>_<timestamp>.md.
+      All runs are kept — they are gitignored but readable locally.
+    - At the end of a build phase, run --stats for a defect count summary.
+    - Failure output shows expected/got explicitly — no editorial commentary.
+"""
+
+import sys
+import argparse
+from pathlib import Path
+from datetime import datetime
+
+_REPO_ROOT = Path(__file__).parent
+_WORKING_DIR = _REPO_ROOT / "_working"
+
+
+class TestReporter:
+    def __init__(self, suite: str, group: str = ""):
+        self.suite = suite
+        self.group = group
+        self._results: list[dict] = []
+        self._run_ts = datetime.now().strftime("%Y%m%d_%H%M")
+
+    def report(
+        self,
+        test_num: str,
+        name: str,
+        passed: bool,
+        detail: str = "",
+        *,
+        expected: str = "",
+        got: str = "",
+    ) -> None:
+        status = "PASS" if passed else "FAIL"
+        suffix = f": {detail}" if detail else ""
+        print(f"Test {test_num} — {name}: {status}{suffix}")
+        self._results.append({
+            "num": test_num,
+            "name": name,
+            "status": status,
+            "detail": detail,
+            "expected": expected,
+            "got": got,
+        })
+
+    def _print_failure_summary(self) -> None:
+        failures = [r for r in self._results if r["status"] == "FAIL"]
+        if not failures:
+            return
+        print("\n" + "─" * 60)
+        print(f"FAILURES ({len(failures)}):")
+        for r in failures:
+            print(f"\n  ❌ {r['num']} — {r['name']}")
+            if r.get("expected"):
+                print(f"     expected : {r['expected']}")
+                print(f"     got      : {r['got']}")
+            elif r.get("detail"):
+                print(f"     detail   : {r['detail']}")
+        print("─" * 60)
+
+    def _write_report(self) -> Path:
+        out_path = _WORKING_DIR / f"test_{self.suite}_{self._run_ts}.md"
+        passed = sum(1 for r in self._results if r["status"] == "PASS")
+        failed = sum(1 for r in self._results if r["status"] == "FAIL")
+        total  = len(self._results)
+        group_label = f" — {self.group}" if self.group else ""
+
+        lines = [
+            f"# {self.suite}{group_label} — Test Results",
+            f"**Run:** {self._run_ts.replace('_', ' ')}  ",
+            f"**Suite:** {self.suite}{group_label}  ",
+            f"**Result:** {passed}/{total} passed" + (f" — **{failed} FAILED**" if failed else ""),
+            "",
+        ]
+
+        failures = [r for r in self._results if r["status"] == "FAIL"]
+        if failures:
+            lines += ["## Failures", ""]
+            for r in failures:
+                lines.append(f"### ❌ {r['num']} — {r['name']}")
+                if r.get("expected"):
+                    lines.append(f"- **Expected:** `{r['expected']}`")
+                    lines.append(f"- **Got:** `{r['got']}`")
+                if r.get("detail"):
+                    lines.append(f"- **Detail:** {r['detail']}")
+                lines.append("")
+            lines += ["---", ""]
+
+        lines += [
+            "## Full Results",
+            "",
+            "| # | Test | Status | Detail |",
+            "|---|------|--------|--------|",
+        ]
+        for r in self._results:
+            icon = "✅" if r["status"] == "PASS" else "❌"
+            detail = r["detail"].replace("|", "\\|")
+            lines.append(f"| {r['num']} | {r['name']} | {icon} {r['status']} | {detail} |")
+
+        out_path.write_text("\n".join(lines) + "\n")
+        return out_path
+
+    def finish(self) -> None:
+        """Print summary, write report, exit with 0 (all pass) or 1 (any fail)."""
+        passed = sum(1 for r in self._results if r["status"] == "PASS")
+        total  = len(self._results)
+        self._print_failure_summary()
+        print(f"\n{passed}/{total} tests passed.")
+        out_path = self._write_report()
+        print(f"Report: {out_path}")
+        sys.exit(0 if passed == total else 1)
+
+
+def print_stats(suite_filter: str = "") -> None:
+    """Print defect summary across all saved reports, optionally filtered by suite name."""
+    pattern = f"test_{suite_filter}*.md" if suite_filter else "test_*.md"
+    reports = sorted(_WORKING_DIR.glob(pattern))
+    if not reports:
+        label = f"suite '{suite_filter}'" if suite_filter else "any suite"
+        print(f"No reports found for {label} in {_WORKING_DIR}/")
+        return
+
+    suites_seen: dict[str, list] = {}
+    for p in reports:
+        # Extract suite name: test_<suite>_YYYYMMDD_HHMM.md
+        stem = p.stem  # e.g. test_german_domain_20260519_0653
+        parts = stem.split("_")
+        # Last two parts are date + time; everything between 'test' and those is the suite
+        suite = "_".join(parts[1:-2]) if len(parts) >= 4 else "_".join(parts[1:])
+        suites_seen.setdefault(suite, []).append(p)
+
+    total_runs = len(reports)
+    total_failures = 0
+
+    print(f"\nBuild phase stats — {total_runs} run(s) across {len(suites_seen)} suite(s):\n")
+    for suite, suite_reports in suites_seen.items():
+        print(f"  {suite}:")
+        suite_failures = 0
+        for p in suite_reports:
+            text = p.read_text()
+            ts = p.stem.split("_")[-2] + " " + p.stem.split("_")[-1]
+            result_line = next((l for l in text.splitlines() if "**Result:**" in l), "")
+            result_str = result_line.replace("**Result:**", "").replace("**", "").strip()
+            fail_count = text.count("❌")
+            suite_failures += fail_count
+            print(f"    {ts}  {result_str}")
+        total_failures += suite_failures
+        if suite_failures:
+            print(f"    → {suite_failures} failure instance(s)")
+        print()
+
+    print(f"  Total failure instances across all runs: {total_failures}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Build-phase test report stats")
+    parser.add_argument("--stats", action="store_true", help="Show stats across all saved reports")
+    parser.add_argument("--suite", type=str, default="", help="Filter stats by suite name")
+    args = parser.parse_args()
+
+    if args.stats:
+        print_stats(suite_filter=args.suite)
+    else:
+        parser.print_help()


### PR DESCRIPTION
## Summary

Extracts all German language domain logic from `telegram_bot.py` into a new `german_domain.py` module. Both the Telegram bot and the planned HTML server will import from this single domain layer.

- **Group A** — constants, regex patterns, data structures, 14 pure functions
- **Group B** — file I/O, subprocess wrapper, LLM callers (14 functions)
- **Group C** — async-free resolver functions with `progress_cb` callback pattern (`_resolve_verb`, `_resolve_phrases`, `_resolve_drill_verb`)
- **Group D** — adapter boundary verified; `telegram_bot.py` now contains only message routing, Whisper transcription, Telegram formatting, and callback delivery

Design spec: `docs/GERMAN_HTML_BUILD_PLAN_v1.0.md`

## Gates passed

- 49/49 behavioral tests (`_NewDomains/language-german/run_tests.py`)
- 32/32 domain unit tests (`_NewDomains/language-german/test_german_domain.py`)
- Clean `import telegram_bot` (venv)
- Identity checks: `telegram_bot._resolve_verb is german_domain._resolve_verb` → True (and for all Group C functions)

## Build artifacts

Detailed reasoning for each group is committed alongside the code in `_working/`:
- `_working/build_note_group_a.md`
- `_working/build_note_group_b.md`
- `_working/build_note_group_c.md`
- `_working/build_note_group_d.md`

## UAT plan

After merge, launchd restarts the bot automatically. Run these 6 messages to `minimoi_cmd_bot`:

1. `next german session` — full session pipeline
2. `conjugate nehmen` — Group C verb resolution
3. `german drill` — drill verb resolution
4. _(answer the drill prompt)_ — drill state and scoring
5. `end drill` — routing
6. `phrase list` — phrase library

**Do not merge** — OpenClaw handles merges per division of labor.